### PR TITLE
fix(containers)!: race conditions between multiple app instances

### DIFF
--- a/containers/api.w
+++ b/containers/api.w
@@ -1,14 +1,9 @@
-pub interface IWorkload extends std.IResource {
-  /** internal url, `nil` if there is no exposed port */
-  getInternalUrl(): str?;
-
-  /** extern url, `nil` if there is no exposed port or if `public` is `false` */
-  getPublicUrl(): str?;
-}
 
 pub struct ContainerOpts {
   name: str;
   image: str;
+
+  /** Internal container port to expose */
   port: num?;
   env: Map<str?>?;
   readiness: str?;   // http get

--- a/containers/workload.tfaws.w
+++ b/containers/workload.tfaws.w
@@ -8,9 +8,9 @@ bring "./utils.w" as utils;
 bring "@cdktf/provider-kubernetes" as k8s;
 bring "@cdktf/provider-helm" as helm;
 
-pub class Workload_tfaws impl api.IWorkload {
-  internalUrl: str?;
-  publicUrl: str?;
+pub class Workload_tfaws {
+  pub internalUrl: str?;
+  pub publicUrl: str?;
 
   new(props: api.WorkloadProps) {
     let cluster = eks.Cluster.getOrCreate(this);
@@ -146,14 +146,6 @@ pub class Workload_tfaws impl api.IWorkload {
       let hostname = ingress.status.get(0).loadBalancer.get(0).ingress.get(0).hostname;
       this.publicUrl = "http://{hostname}";
     }
-  }
-
-  pub getPublicUrl(): str? {
-    return this.publicUrl;
-  }
-
-  pub getInternalUrl(): str? {
-    return this.internalUrl;
   }
 }
 

--- a/containers/workload.w
+++ b/containers/workload.w
@@ -4,32 +4,29 @@ bring "./workload.tfaws.w" as tfaws;
 bring "./api.w" as api;
 bring "./utils.w" as utils;
 
-pub class Workload impl api.IWorkload {
-  inner: api.IWorkload;
+bring http;
+
+pub class Workload {
+  /** internal url, `nil` if there is no exposed port */
   pub internalUrl: str?;
+
+  /** extern url, `nil` if there is no exposed port or if `public` is `false` */
   pub publicUrl: str?;
 
   new(props: api.WorkloadProps) {
     let target = util.env("WING_TARGET");
 
     if target == "sim" {
-      this.inner = new sim.Workload_sim(props) as props.name;
+      let w = new sim.Workload_sim(props) as props.name;
+      this.internalUrl = w.internalUrl;
+      this.publicUrl = w.publicUrl;
+
     } elif target == "tf-aws" {
-      this.inner = new tfaws.Workload_tfaws(props) as props.name;
+      let w = new tfaws.Workload_tfaws(props) as props.name;
+      this.internalUrl = w.internalUrl;
+      this.publicUrl = w.publicUrl;
     } else {
       throw "unsupported target {target}";
     }
-
-    
-    this.internalUrl = this.inner.getInternalUrl();
-    this.publicUrl = this.inner.getPublicUrl();
-  }
-
-  pub getInternalUrl(): str? {
-    return this.inner.getInternalUrl();
-  }
-
-  pub getPublicUrl(): str? {
-    return this.inner.getPublicUrl();
   }
 }


### PR DESCRIPTION
When running tests in Wing, an isolated environment is created for every test. This means we must create a the container workload using a unique name, or otherwise the containers will mix up with each other.

BREAKING CHANGE: the `getPublicUrl()` and `getInternalUrl()` APIs were replaced with properties (`publicUrl` and `internalUrl`).