### PR TITLE
fix(containers): missing return type for cluster attributes in latest wing version

### DIFF
--- a/containers/ecr.main.w
+++ b/containers/ecr.main.w
@@ -1,5 +1,5 @@
-bring "../tfaws-ecr.w" as ecr;
-bring "../utils.w" as utils;
+bring "./tfaws-ecr.w" as ecr;
+bring "./utils.w" as utils;
 
 new ecr.Repository(
   name: "my-repository",

--- a/containers/package-lock.json
+++ b/containers/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/containers",
-  "version": "0.0.16",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/containers",
-      "version": "0.0.16",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
         "@cdktf/provider-aws": "^18.0.5",
@@ -19,7 +19,7 @@
       },
       "peerDependencies": {
         "cdktf": "^0.19.1",
-        "winglang": "^0.44.3"
+        "winglang": "^0.54.13"
       }
     },
     "node_modules/@cdktf/provider-aws": {
@@ -827,31 +827,32 @@
       }
     },
     "node_modules/@segment/analytics-core": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
-      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.4.0.tgz",
+      "integrity": "sha512-rLUv5Se0iDccykxY8bWUuoZT4gg8fNW00zMPqkJN+ONfj5/P1eaGQgygq2EHlR9j20a7tNtp5Y9bZ4rLzViIXQ==",
       "peer": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.1.0",
         "dset": "^3.1.2",
         "tslib": "^2.4.1"
       }
     },
     "node_modules/@segment/analytics-generic-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.0.0.tgz",
-      "integrity": "sha512-rAqcIQESnCsc80DMAxH06C4sJQ1MjwRLrWsih9qA2E0XwxydrMYgLA8eazxLW/wqEdctSJHCPnkMynpPIQgatw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.1.0.tgz",
+      "integrity": "sha512-nOgmbfsKD0jFzH3df+PtjLq3qTspdcFpIy/F5ziho5qiE+QATM8wY9TpvCNBbcHr2f3OGzT6SgjJLFlmM5Yb+w==",
       "peer": true
     },
     "node_modules/@segment/analytics-node": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.3.tgz",
-      "integrity": "sha512-RGmD/VIW4iHqY+raeHlxdGY/FQpE6ATZHU8LrbwI+16uvT+sfw8d725J/lmzJIgNScJ/NFLg3LyHjitwPpqTxw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.4.tgz",
+      "integrity": "sha512-yfhWjos0VKrueIhL7NwwaKJTMmDTDPMeNA9nmCZbbIppxWfgfUdqhkSOktQKTUdxLHOygTwuldvayjuftBsRBA==",
       "peer": true,
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.3.2",
-        "@segment/analytics-generic-utils": "1.0.0",
+        "@segment/analytics-core": "1.4.0",
+        "@segment/analytics-generic-utils": "1.1.0",
         "buffer": "^6.0.3",
         "node-fetch": "^2.6.7",
         "tslib": "^2.4.1"
@@ -961,24 +962,26 @@
       "optional": true
     },
     "node_modules/@wingconsole/app": {
-      "version": "0.44.7",
-      "resolved": "https://registry.npmjs.org/@wingconsole/app/-/app-0.44.7.tgz",
-      "integrity": "sha512-3pvf61ariR/GAzXCQnv31iYf/jN3VujdEySnu59hfDFhXdO548rSLP7id4z61+37k7D6DeK2MjoGEbJE9mI6lw==",
+      "version": "0.54.13",
+      "resolved": "https://registry.npmjs.org/@wingconsole/app/-/app-0.54.13.tgz",
+      "integrity": "sha512-MgiYQjVfOKNJN/u7PDzSFSdswwD5dNlpB/N0Y5LrDuF4Q0IKlwixO72P1qBfwEQgs9qu68Vn+m2gZwpxxLn9ag==",
       "peer": true,
       "dependencies": {
         "@segment/analytics-node": "^1.1.0",
-        "@wingconsole/server": "0.44.7",
-        "express": "^4.18.2"
+        "@wingconsole/server": "0.54.13",
+        "cross-spawn": "^7.0.3",
+        "express": "^4.18.2",
+        "picocolors": "^1.0.0"
       }
     },
     "node_modules/@wingconsole/server": {
-      "version": "0.44.7",
-      "resolved": "https://registry.npmjs.org/@wingconsole/server/-/server-0.44.7.tgz",
-      "integrity": "sha512-7VPzshRc6rRsnORkdLXaRV1bGEMPiigH0TltFb81bE5aenNsgfxetUs9lulg3+v9UWYtg7etkrjZmrz0WJHEiw==",
+      "version": "0.54.13",
+      "resolved": "https://registry.npmjs.org/@wingconsole/server/-/server-0.54.13.tgz",
+      "integrity": "sha512-j37vvdraxC10c0SCCxI5cMxaO7E+x2C6RbhYAh4LXaCFw0RTMQV8143XP7Z9uEpw+iIyy4lYOKZxl+7IpH3/cw==",
       "peer": true,
       "dependencies": {
-        "@winglang/compiler": "0.44.7",
-        "@winglang/sdk": "0.44.7",
+        "@winglang/compiler": "0.54.13",
+        "@winglang/sdk": "0.54.13",
         "codespan-wasm": "^0.4.0",
         "debug": "^4.3.4",
         "launch-editor": "^2.6.0",
@@ -986,15 +989,16 @@
       }
     },
     "node_modules/@winglang/compiler": {
-      "version": "0.44.7",
-      "resolved": "https://registry.npmjs.org/@winglang/compiler/-/compiler-0.44.7.tgz",
-      "integrity": "sha512-vESjyoHZfiSaesZra5YzuQbmEs82vX12ZQyBWJB7N/DV20niGc9jjAlpczqevGJd1CjAMkY3752PGjjmbvMVZA==",
+      "version": "0.54.13",
+      "resolved": "https://registry.npmjs.org/@winglang/compiler/-/compiler-0.54.13.tgz",
+      "integrity": "sha512-nsAV8cJve0utw2xy62qf4OOoLv9P4PP5fOiuVx3wZGm6BTQpBl4JqiP42OfOHyKripGZPzSuJWeCHUZ+k+I1gQ==",
       "bundleDependencies": [
         "wasi-js"
       ],
       "peer": true,
       "dependencies": {
-        "@winglang/sdk": "0.44.7",
+        "@winglang/sdk": "0.54.13",
+        "ts4w": "0.54.13",
         "wasi-js": "^1.7.3"
       },
       "engines": {
@@ -1140,9 +1144,9 @@
       }
     },
     "node_modules/@winglang/sdk": {
-      "version": "0.44.7",
-      "resolved": "https://registry.npmjs.org/@winglang/sdk/-/sdk-0.44.7.tgz",
-      "integrity": "sha512-2ihRi+88aWzJTXnJd0LQ2UFBwg7M6RA6KiqHbKlqzaolgbHIyWQQbGll1wNWsb/ugBEc54tQn/qIJ0CY/h10Aw==",
+      "version": "0.54.13",
+      "resolved": "https://registry.npmjs.org/@winglang/sdk/-/sdk-0.54.13.tgz",
+      "integrity": "sha512-x76qhEXrhdYqyUHtlw067M3tFxnv+dVd2+vUy2a80ypmPmbZdOJwr3BgtvzLUQQBHjjXB+XFKlg3CqBrpphYGg==",
       "bundleDependencies": [
         "@aws-sdk/client-cloudwatch-logs",
         "@aws-sdk/client-dynamodb",
@@ -1166,29 +1170,32 @@
         "cron-parser",
         "esbuild-wasm",
         "express",
+        "google-auth-library",
         "ioredis",
         "jsonschema",
         "mime",
         "mime-types",
         "nanoid",
         "safe-stable-stringify",
+        "stacktracey",
+        "ulid",
         "undici",
         "uuid",
         "yaml"
       ],
       "peer": true,
       "dependencies": {
-        "@aws-sdk/client-cloudwatch-logs": "3.438.0",
-        "@aws-sdk/client-dynamodb": "3.438.0",
-        "@aws-sdk/client-elasticache": "3.438.0",
-        "@aws-sdk/client-lambda": "3.438.0",
-        "@aws-sdk/client-s3": "3.438.0",
-        "@aws-sdk/client-secrets-manager": "3.438.0",
-        "@aws-sdk/client-sns": "3.438.0",
-        "@aws-sdk/client-sqs": "3.438.0",
-        "@aws-sdk/s3-request-presigner": "3.438.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-dynamodb": "3.438.0",
+        "@aws-sdk/client-cloudwatch-logs": "3.449.0",
+        "@aws-sdk/client-dynamodb": "3.449.0",
+        "@aws-sdk/client-elasticache": "3.449.0",
+        "@aws-sdk/client-lambda": "3.449.0",
+        "@aws-sdk/client-s3": "3.449.0",
+        "@aws-sdk/client-secrets-manager": "3.449.0",
+        "@aws-sdk/client-sns": "3.449.0",
+        "@aws-sdk/client-sqs": "3.449.0",
+        "@aws-sdk/s3-request-presigner": "3.449.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-dynamodb": "3.449.0",
         "@azure/core-paging": "^1.5.0",
         "@azure/identity": "3.1.3",
         "@azure/storage-blob": "12.14.0",
@@ -1201,12 +1208,15 @@
         "cron-parser": "^4.9.0",
         "esbuild-wasm": "^0.18.20",
         "express": "^4.18.2",
+        "google-auth-library": "^8.9.0",
         "ioredis": "^5.3.2",
         "jsonschema": "^1.4.1",
         "mime": "^3.0.0",
         "mime-types": "^2.1.35",
         "nanoid": "^3.3.6",
         "safe-stable-stringify": "^2.4.3",
+        "stacktracey": "^2.1.8",
+        "ulid": "^2.3.0",
         "undici": "^5.25.4",
         "uuid": "^8.3.2",
         "yaml": "^2.3.2"
@@ -1312,26 +1322,26 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-cloudwatch-logs": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/client-sts": "3.449.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/credential-provider-node": "3.449.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/fetch-http-handler": "^2.2.4",
         "@smithy/hash-node": "^2.0.12",
@@ -1363,27 +1373,27 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.433.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/client-sts": "3.449.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/credential-provider-node": "3.449.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.449.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/fetch-http-handler": "^2.2.4",
         "@smithy/hash-node": "^2.0.12",
@@ -1416,26 +1426,26 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-elasticache": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/client-sts": "3.449.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/credential-provider-node": "3.449.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/fetch-http-handler": "^2.2.4",
         "@smithy/hash-node": "^2.0.12",
@@ -1468,26 +1478,26 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-lambda": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/client-sts": "3.449.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/credential-provider-node": "3.449.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/eventstream-serde-browser": "^2.0.12",
         "@smithy/eventstream-serde-config-resolver": "^2.0.12",
@@ -1523,7 +1533,7 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-s3": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1531,26 +1541,26 @@
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.433.0",
-        "@aws-sdk/middleware-expect-continue": "3.433.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.433.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-location-constraint": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-s3": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-ssec": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/client-sts": "3.449.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/credential-provider-node": "3.449.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.449.0",
+        "@aws-sdk/middleware-expect-continue": "3.449.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.449.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-location-constraint": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-sdk-s3": "3.449.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/middleware-ssec": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/signature-v4-multi-region": "3.437.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/signature-v4-multi-region": "3.449.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@aws-sdk/xml-builder": "3.310.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/eventstream-serde-browser": "^2.0.12",
@@ -1591,26 +1601,26 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/client-sts": "3.449.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/credential-provider-node": "3.449.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/fetch-http-handler": "^2.2.4",
         "@smithy/hash-node": "^2.0.12",
@@ -1642,26 +1652,26 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-sns": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/client-sts": "3.449.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/credential-provider-node": "3.449.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/fetch-http-handler": "^2.2.4",
         "@smithy/hash-node": "^2.0.12",
@@ -1693,27 +1703,27 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-sqs": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.438.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/client-sts": "3.449.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/credential-provider-node": "3.449.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.449.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/fetch-http-handler": "^2.2.4",
         "@smithy/hash-node": "^2.0.12",
@@ -1738,7 +1748,6 @@
         "@smithy/util-endpoints": "^1.0.2",
         "@smithy/util-retry": "^2.0.5",
         "@smithy/util-utf8": "^2.0.0",
-        "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1746,23 +1755,23 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-sso": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/fetch-http-handler": "^2.2.4",
         "@smithy/hash-node": "^2.0.12",
@@ -1793,26 +1802,26 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/client-sts": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/core": "3.436.0",
-        "@aws-sdk/credential-provider-node": "3.438.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-sts": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/core": "3.445.0",
+        "@aws-sdk/credential-provider-node": "3.449.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-sdk-sts": "3.449.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/fetch-http-handler": "^2.2.4",
         "@smithy/hash-node": "^2.0.12",
@@ -1844,24 +1853,25 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/core": {
-      "version": "3.436.0",
+      "version": "3.445.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@smithy/smithy-client": "^2.1.12"
+        "@smithy/smithy-client": "^2.1.12",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -1871,16 +1881,16 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.438.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/credential-provider-env": "3.449.0",
+        "@aws-sdk/credential-provider-process": "3.449.0",
+        "@aws-sdk/credential-provider-sso": "3.449.0",
+        "@aws-sdk/credential-provider-web-identity": "3.449.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
@@ -1892,17 +1902,17 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-ini": "3.438.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.438.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/credential-provider-env": "3.449.0",
+        "@aws-sdk/credential-provider-ini": "3.449.0",
+        "@aws-sdk/credential-provider-process": "3.449.0",
+        "@aws-sdk/credential-provider-sso": "3.449.0",
+        "@aws-sdk/credential-provider-web-identity": "3.449.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
@@ -1914,12 +1924,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
         "@smithy/types": "^2.4.0",
@@ -1930,14 +1940,14 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.438.0",
-        "@aws-sdk/token-providers": "3.438.0",
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/client-sso": "3.449.0",
+        "@aws-sdk/token-providers": "3.449.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.6",
         "@smithy/types": "^2.4.0",
@@ -1948,12 +1958,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -1976,12 +1986,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
         "@smithy/node-config-provider": "^2.1.3",
         "@smithy/protocol-http": "^3.0.8",
@@ -1994,13 +2004,13 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "3.310.0",
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/node-config-provider": "^2.1.3",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/types": "^2.4.0",
@@ -2011,12 +2021,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -2026,14 +2036,14 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/is-array-buffer": "^2.0.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/types": "^2.4.0",
@@ -2045,12 +2055,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -2060,12 +2070,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
@@ -2074,12 +2084,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
@@ -2088,12 +2098,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -2103,12 +2113,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/smithy-client": "^2.1.12",
@@ -2120,12 +2130,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/types": "^2.4.0",
         "@smithy/util-hex-encoding": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
@@ -2136,13 +2146,13 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/middleware-signing": "3.449.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
@@ -2151,12 +2161,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/signature-v4": "^2.0.0",
@@ -2169,12 +2179,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
       },
@@ -2183,13 +2193,13 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -2215,14 +2225,14 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.437.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-format-url": "3.433.0",
+        "@aws-sdk/signature-v4-multi-region": "3.449.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-format-url": "3.449.0",
         "@smithy/middleware-endpoint": "^2.1.3",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/smithy-client": "^2.1.12",
@@ -2234,12 +2244,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.437.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/signature-v4": "^2.0.0",
         "@smithy/types": "^2.4.0",
@@ -2250,22 +2260,22 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/token-providers": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.438.0",
+        "@aws-sdk/middleware-host-header": "3.449.0",
+        "@aws-sdk/middleware-logger": "3.449.0",
+        "@aws-sdk/middleware-recursion-detection": "3.449.0",
+        "@aws-sdk/middleware-user-agent": "3.449.0",
         "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.438.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@aws-sdk/types": "3.449.0",
+        "@aws-sdk/util-endpoints": "3.449.0",
+        "@aws-sdk/util-user-agent-browser": "3.449.0",
+        "@aws-sdk/util-user-agent-node": "3.449.0",
         "@smithy/config-resolver": "^2.0.16",
         "@smithy/fetch-http-handler": "^2.2.4",
         "@smithy/hash-node": "^2.0.12",
@@ -2298,7 +2308,7 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -2323,7 +2333,7 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -2338,12 +2348,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.438.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/util-endpoints": "^1.0.2",
         "tslib": "^2.5.0"
       },
@@ -2352,12 +2362,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/util-format-url": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/querystring-builder": "^2.0.12",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -2379,24 +2389,24 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.433.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/types": "^2.4.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@winglang/sdk/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.437.0",
+      "version": "3.449.0",
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/types": "3.449.0",
         "@smithy/node-config-provider": "^2.1.3",
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -3499,6 +3509,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/@winglang/sdk/node_modules/as-table": {
+      "version": "1.0.55",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
     "node_modules/@winglang/sdk/node_modules/async-retry": {
       "version": "1.3.3",
       "inBundle": true,
@@ -4287,6 +4306,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@winglang/sdk/node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@winglang/sdk/node_modules/debug": {
       "version": "4.3.4",
       "inBundle": true,
@@ -4619,6 +4644,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/get-source": {
+      "version": "2.0.12",
+      "inBundle": true,
+      "license": "Unlicense",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
       }
     },
     "node_modules/@winglang/sdk/node_modules/google-auth-library": {
@@ -5183,6 +5218,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@winglang/sdk/node_modules/printable-characters": {
+      "version": "1.0.42",
+      "inBundle": true,
+      "license": "Unlicense",
+      "peer": true
+    },
     "node_modules/@winglang/sdk/node_modules/process": {
       "version": "0.11.10",
       "inBundle": true,
@@ -5416,6 +5457,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@winglang/sdk/node_modules/source-map": {
+      "version": "0.6.1",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/stacktracey": {
+      "version": "2.1.8",
+      "inBundle": true,
+      "license": "Unlicense",
+      "peer": true,
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
     "node_modules/@winglang/sdk/node_modules/standard-as-callback": {
       "version": "2.1.0",
       "inBundle": true,
@@ -5534,6 +5594,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/ulid": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "ulid": "bin/cli.js"
       }
     },
     "node_modules/@winglang/sdk/node_modules/undici": {
@@ -7263,12 +7332,20 @@
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "optional": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dset": {
@@ -10219,6 +10296,28 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts4w": {
+      "version": "0.54.13",
+      "resolved": "https://registry.npmjs.org/ts4w/-/ts4w-0.54.13.tgz",
+      "integrity": "sha512-V0Hfcqyk4vp1U0VrUw+uKC4GtNoR3vWPlYbGnx4mEcfrhcJtvAlv52wANEspPJHHvuB3FtcH5OtVJ1+PENfwcA==",
+      "peer": true,
+      "dependencies": {
+        "@winglang/sdk": "0.54.13",
+        "constructs": "~10.2.69"
+      },
+      "peerDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/ts4w/node_modules/constructs": {
+      "version": "10.2.70",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.70.tgz",
+      "integrity": "sha512-z6zr1E8K/9tzJbCQzY0UGX0/oVKPFKu9C/mzEnghCG6TAJINnvlq0CMKm63XqqeMleadZYm5T3sZGJKcxJS/Pg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 16.14.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -10261,6 +10360,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unique-filename": {
@@ -10460,24 +10572,25 @@
       }
     },
     "node_modules/winglang": {
-      "version": "0.44.7",
-      "resolved": "https://registry.npmjs.org/winglang/-/winglang-0.44.7.tgz",
-      "integrity": "sha512-1DBUFZ43sWyPmLBxqe28ZdmgOWjVEvJHXAoONDsS2UhD5JEaDy24FijUh4E6hjYfuWqU7CPyVPaD7KTtVvmgHQ==",
+      "version": "0.54.13",
+      "resolved": "https://registry.npmjs.org/winglang/-/winglang-0.54.13.tgz",
+      "integrity": "sha512-zXS6FftI8SWVF5/+iaXNVw96yN5b87MGrZ8OBEssaFni0Z6eydZfc02sFdZzgJIZBfoqVFeTyjMClUsISLrESg==",
       "peer": true,
       "dependencies": {
         "@npmcli/arborist": "^7.2.0",
         "@segment/analytics-node": "^1.1.0",
-        "@wingconsole/app": "0.44.7",
-        "@wingconsole/server": "0.44.7",
-        "@winglang/compiler": "0.44.7",
-        "@winglang/sdk": "0.44.7",
+        "@wingconsole/app": "0.54.13",
+        "@wingconsole/server": "0.54.13",
+        "@winglang/compiler": "0.54.13",
+        "@winglang/sdk": "0.54.13",
         "chalk": "^4.1.2",
         "codespan-wasm": "0.4.0",
         "commander": "^10.0.1",
         "compare-versions": "^5.0.3",
         "debug": "^4.3.4",
+        "dotenv": "^16.3.1",
+        "dotenv-expand": "^10.0.0",
         "glob": "^10.3.10",
-        "minimatch": "^9.0.3",
         "nanoid": "^3.3.6",
         "npm-packlist": "^8.0.0",
         "open": "^8.4.2",

--- a/containers/package.json
+++ b/containers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/containers",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Container support for Wing",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "winglang": "^0.44.3",
+    "winglang": "^0.54.13",
     "cdktf": "^0.19.1"
   },
   "dependencies": {

--- a/containers/tfaws-eks.w
+++ b/containers/tfaws-eks.w
@@ -21,7 +21,11 @@ interface ICluster extends std.IResource {
 }
 
 pub class ClusterBase impl ICluster {
-  pub attributes(): ClusterAttributes { throw "Not implemented"; return { certificate: "", endpoint: "", name: "" }; }
+  pub attributes(): ClusterAttributes { 
+    throw "Not implemented"; 
+    // WORKAROUND: Compiler doesn't recognize that this will never return, so we need to return something
+    return { certificate: "", endpoint: "", name: "" }; 
+  }
 
   pub kubernetesProvider(): cdktf.TerraformProvider {
     let stack = cdktf.TerraformStack.of(this);

--- a/containers/tfaws-eks.w
+++ b/containers/tfaws-eks.w
@@ -21,7 +21,7 @@ interface ICluster extends std.IResource {
 }
 
 pub class ClusterBase impl ICluster {
-  pub attributes(): ClusterAttributes { throw "Not implemented"; }
+  pub attributes(): ClusterAttributes { throw "Not implemented"; return { certificate: "", endpoint: "", name: "" }; }
 
   pub kubernetesProvider(): cdktf.TerraformProvider {
     let stack = cdktf.TerraformStack.of(this);


### PR DESCRIPTION
Update containers to latest wing version, which requires a workaround for "not implemented"-esque throw