### PR TITLE
fix(fifo-queue): wrong return type for cloud.Function in latest wing version

### DIFF
--- a/fifoqueue/fifo-queue.aws.w
+++ b/fifoqueue/fifo-queue.aws.w
@@ -30,7 +30,7 @@ pub class FifoQueue_aws impl api.IFifoQueue {
   }
 
   pub setConsumer(handler: inflight (str) : void, options: api.SetConsumerOptions?) {
-    let lambdaFn = new cloud.Function(inflight (event: str): void => {
+    let lambdaFn = new cloud.Function(inflight (event) => {
       let json: Json = unsafeCast(event);
       let sqsEvent = SqsEvent.fromJson(event);
       for message in sqsEvent.Records {

--- a/fifoqueue/package-lock.json
+++ b/fifoqueue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/fifoqueue",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/fifoqueue",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.460.0",

--- a/fifoqueue/package.json
+++ b/fifoqueue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/fifoqueue",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A wing library to work with FIFO (first-in first-out) Queues",
   "author": {
     "name": "Elad Cohen",


### PR DESCRIPTION
The void return type is not correct now