### PR TITLE
fix(websockets)!: fix token usage in simulator

### DIFF
--- a/websockets/commons/api.w
+++ b/websockets/commons/api.w
@@ -24,14 +24,6 @@ pub interface IWebSocket extends std.IResource {
    * Sends a message through the WebSocket with inflight handling.
    */
   inflight sendMessage(connectionId: str, message: str);
-  /**
-   * Retrieves the URL associated with the WebSocket on inflight.
-   */
-   inflight inflightUrl(): str;
-  /**
-   * Retrieves the URL associated with the WebSocket on preflight.
-   */
-  url(): str;
 }
 
 /**

--- a/websockets/lib.test.w
+++ b/websockets/lib.test.w
@@ -51,7 +51,7 @@ class Util {
 let counter = new cloud.Counter(initial: 1);
 
 let receiver = new cloud.Service(inflight () => {
-  let ws = Util._ws(wb.inflightUrl());
+  let ws = Util._ws(wb.url);
 
   ws.on("open", () => {
     log("open socket (receiver)");
@@ -75,7 +75,7 @@ let receiver = new cloud.Service(inflight () => {
 }, autoStart: false) as "receive message";
 
 let sender = new cloud.Service(inflight () => {
-  let ws = Util._ws(wb.inflightUrl());
+  let ws = Util._ws(wb.url);
 
   ws.on("open", () => {
     log("open socket (sender)");

--- a/websockets/lib.w
+++ b/websockets/lib.w
@@ -6,16 +6,24 @@ bring "./platform/sim.w" as sim;
 
 pub class WebSocket impl api.IWebSocket {
   inner: api.IWebSocket;
+
+  pub url: str;
   
   new(props: api.WebSocketProps) {
     let target = util.env("WING_TARGET");
 
     if target == "tf-aws" {
-      this.inner = new tfaws.WebSocket_tfaws(props) as props.name;
+      let ws = new tfaws.WebSocket_tfaws(props) as props.name;
+      this.url = ws.url;
+      this.inner = ws;
     } elif target == "awscdk" {
-      this.inner = new awscdk.WebSocket_awscdk(props) as props.name;
+      let ws = new awscdk.WebSocket_awscdk(props) as props.name;
+      this.url = ws.url;
+      this.inner = ws;
     } elif target == "sim" {
-      this.inner = new sim.WebSocket_sim(props) as props.name;
+      let ws = new sim.WebSocket_sim(props) as props.name;
+      this.url = ws.url;
+      this.inner = ws;
     } else {
       throw "unsupported target {target}";
     }
@@ -31,16 +39,8 @@ pub class WebSocket impl api.IWebSocket {
     this.inner.onMessage(handler);
   }
 
-  pub url(): str {
-    return this.inner.url();
-  }
-
   pub initialize() {
     this.inner.initialize();
-  }
-
-  pub inflight inflightUrl(): str {
-    return this.inner.inflightUrl();
   }
 
   pub inflight sendMessage(connectionId: str, message: str) {

--- a/websockets/package-lock.json
+++ b/websockets/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "@winglibs/websockets",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/websockets",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.451.0",
         "@cdktf/provider-aws": "^18.0.5",
         "aws-cdk-lib": "^2.109.0",
-        "get-port": "^7.0.0"
+        "get-port": "^7.0.0",
+        "ws": "^8.14.2"
       },
       "devDependencies": {
-        "@types/ws": "^8.5.10",
-        "ws": "^8.14.2"
+        "@types/ws": "^8.5.10"
       },
       "peerDependencies": {
         "cdktf": "^0.19.1",
@@ -883,6 +883,15 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -6731,7 +6740,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -6865,6 +6875,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -8763,6 +8774,7 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -9592,6 +9604,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -9606,6 +9619,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10474,7 +10488,6 @@
       "version": "8.14.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
       "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10494,7 +10507,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "peer": true
     }
   }
 }

--- a/websockets/package.json
+++ b/websockets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/websockets",
   "description": "WebSocket library for Wing",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/websockets/platform/awscdk.w
+++ b/websockets/platform/awscdk.w
@@ -9,7 +9,7 @@ pub class WebSocket_awscdk impl awsapi.IAwsWebSocket {
   role: awscdk.aws_iam.Role;
   deployment: awscdk.aws_apigatewayv2.CfnDeployment;
   region: str?;
-  invokeUrl: str;
+  pub url: str;
 
   new(props: commons.WebSocketProps) {
     
@@ -37,10 +37,10 @@ pub class WebSocket_awscdk impl awsapi.IAwsWebSocket {
     this.region = awscdk.Stack.of(this).region;
     let urlSuffix = awscdk.Stack.of(this).urlSuffix;
 
-    this.invokeUrl = this.api.attrApiEndpoint;
+    this.url = this.api.attrApiEndpoint;
 
     new awscdk.CfnOutput(
-      value: this.invokeUrl,
+      value: this.url,
       exportName: "url"
     ) as "url";
 
@@ -147,17 +147,8 @@ pub class WebSocket_awscdk impl awsapi.IAwsWebSocket {
     }
   }
 
-  pub url(): str {
-    return this.invokeUrl;
-  }
-
-  pub inflight inflightUrl(): str {
-    return this.invokeUrl;
-  }
-
   extern "../inflight/websocket.aws.js" static inflight _postToConnection(endpointUrl: str, connectionId: str, message: str): void;
   pub inflight sendMessage(connectionId: str, message: str) {
-    let url = this.inflightUrl();
-    WebSocket_awscdk._postToConnection(url.replace("wss://", "https://"), connectionId, message);
+    WebSocket_awscdk._postToConnection(this.url.replace("wss://", "https://"), connectionId, message);
   }
 }

--- a/websockets/platform/sim.w
+++ b/websockets/platform/sim.w
@@ -13,19 +13,17 @@ pub class WebSocket_sim impl api.IWebSocket {
   var disconnectFn: inflight(str): void;
   var messageFn: inflight(str, str): void;
   state: sim.State;
-  preflightUrlToken: str;
-  inflight inflightUrlToken: str;
+  urlStateKey: str;
+
+  pub url: str;
 
   new(props: api.WebSocketProps) {
     this.connectFn = inflight () => {};
     this.disconnectFn = inflight () => {};
     this.messageFn = inflight () => {};
     this.state = new sim.State();
-    this.preflightUrlToken = "invokeUrl";
-  }
-
-  inflight new() {
-    this.inflightUrlToken = "invokeUrl";
+    this.urlStateKey = "url";
+    this.url = this.state.token(this.urlStateKey);
   }
 
   pub onConnect(handler: inflight(str): void): void {
@@ -38,22 +36,14 @@ pub class WebSocket_sim impl api.IWebSocket {
     this.messageFn = handler;
   }
 
-  pub url(): str {
-    return this.state.token(this.preflightUrlToken);
-  }
-
   pub initialize() {
     new cloud.Service(inflight () => {
       let res = WebSocket_sim._startWebSocketApi(this.connectFn, this.disconnectFn, this.messageFn);
-      this.state.set(this.inflightUrlToken, res.url());
+      this.state.set(this.urlStateKey, res.url());
       return () => {
         res.close();
       };
     });
-  }
-
-  pub inflight inflightUrl(): str {
-    return str.fromJson(this.state.get(this.inflightUrlToken));
   }
 
   extern "./sim/wb.js" static inflight _startWebSocketApi(

--- a/websockets/platform/tf-aws.w
+++ b/websockets/platform/tf-aws.w
@@ -8,7 +8,7 @@ bring "./aws/api.w" as awsapi;
 pub class WebSocket_tfaws impl awsapi.IAwsWebSocket {
   webSocketApi: tfaws.apigatewayv2Api.Apigatewayv2Api;
   role: tfaws.iamRole.IamRole;
-  invokeUrl: str;
+  pub url: str;
 
   new(props: commons.WebSocketProps) {
 
@@ -40,7 +40,7 @@ pub class WebSocket_tfaws impl awsapi.IAwsWebSocket {
       autoDeploy: true,
     );
 
-    this.invokeUrl = stage.invokeUrl;
+    this.url = stage.invokeUrl;
   }
 
   pub onLift(host: std.IInflightHost, ops: Array<str>) {
@@ -66,7 +66,7 @@ pub class WebSocket_tfaws impl awsapi.IAwsWebSocket {
         body: "ack"
       };
     }), env: {
-      "url": this.invokeUrl,
+      "url": this.url,
     }) as "on connect";
 
     this.addRoute(onConnectFunction, routeKey);
@@ -83,7 +83,7 @@ pub class WebSocket_tfaws impl awsapi.IAwsWebSocket {
         body: "ack"
       };
     }), env: {
-      "url": this.invokeUrl,
+      "url": this.url,
     }) as "on disconnect";
 
     this.addRoute(onDisconnectFunction, routeKey);
@@ -100,7 +100,7 @@ pub class WebSocket_tfaws impl awsapi.IAwsWebSocket {
         body: "ack"
       };
     }), env: {
-      "url": this.invokeUrl,
+      "url": this.url,
     }) as "on message";
 
     this.addRoute(onMessageFunction, routeKey);
@@ -144,17 +144,8 @@ pub class WebSocket_tfaws impl awsapi.IAwsWebSocket {
     }
   }
 
-  pub url(): str {
-    return this.invokeUrl;
-  }
-
-  pub inflight inflightUrl(): str {
-    return this.invokeUrl;
-  }
-
   extern "../inflight/websocket.aws.js" static inflight _postToConnection(endpointUrl: str, connectionId: str, message: str): void;
   pub inflight sendMessage(connectionId: str, message: str) {
-    let url = this.inflightUrl();
-    WebSocket_tfaws._postToConnection(url.replace("wss://", "https://"), connectionId, message);
+    WebSocket_tfaws._postToConnection(this.url.replace("wss://", "https://"), connectionId, message);
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: the `url()` and `inflightUrl()` methods have been removed in favor of a `url` property.