### PR TITLE
chore: set up GitHub releases

### DIFF
--- a/.github/workflows/bedrock-release.yaml
+++ b/.github/workflows/bedrock-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          name: Winglib bedrock v${{ env.WINGLIB_VERSION }}
+          name: bedrock v${{ env.WINGLIB_VERSION }}
           tag_name: bedrock-v${{ env.WINGLIB_VERSION }}
           files: "*.tgz"
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/bedrock-release.yaml
+++ b/.github/workflows/bedrock-release.yaml
@@ -29,9 +29,25 @@ jobs:
       - name: Pack
         run: wing pack
         working-directory: bedrock
+      - name: Get package version
+        run: echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
+          "$GITHUB_ENV"
+        working-directory: bedrock
       - name: Publish
         run: npm publish --access=public --registry https://registry.npmjs.org --tag
           latest *.tgz
         working-directory: bedrock
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          tag: bedrock-v${{ env.WINGLIB_VERSION }}
+      - name: GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Winglib bedrock v${{ env.WINGLIB_VERSION }}
+          tag_name: bedrock-v${{ env.WINGLIB_VERSION }}
+          files: "*.tgz"
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/checks-release.yaml
+++ b/.github/workflows/checks-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          name: Winglib checks v${{ env.WINGLIB_VERSION }}
+          name: checks v${{ env.WINGLIB_VERSION }}
           tag_name: checks-v${{ env.WINGLIB_VERSION }}
           files: "*.tgz"
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/checks-release.yaml
+++ b/.github/workflows/checks-release.yaml
@@ -29,9 +29,25 @@ jobs:
       - name: Pack
         run: wing pack
         working-directory: checks
+      - name: Get package version
+        run: echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
+          "$GITHUB_ENV"
+        working-directory: checks
       - name: Publish
         run: npm publish --access=public --registry https://registry.npmjs.org --tag
           latest *.tgz
         working-directory: checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          tag: checks-v${{ env.WINGLIB_VERSION }}
+      - name: GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Winglib checks v${{ env.WINGLIB_VERSION }}
+          tag_name: checks-v${{ env.WINGLIB_VERSION }}
+          files: "*.tgz"
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/containers-release.yaml
+++ b/.github/workflows/containers-release.yaml
@@ -29,9 +29,25 @@ jobs:
       - name: Pack
         run: wing pack
         working-directory: containers
+      - name: Get package version
+        run: echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
+          "$GITHUB_ENV"
+        working-directory: containers
       - name: Publish
         run: npm publish --access=public --registry https://registry.npmjs.org --tag
           latest *.tgz
         working-directory: containers
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          tag: containers-v${{ env.WINGLIB_VERSION }}
+      - name: GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Winglib containers v${{ env.WINGLIB_VERSION }}
+          tag_name: containers-v${{ env.WINGLIB_VERSION }}
+          files: "*.tgz"
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/containers-release.yaml
+++ b/.github/workflows/containers-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          name: Winglib containers v${{ env.WINGLIB_VERSION }}
+          name: containers v${{ env.WINGLIB_VERSION }}
           tag_name: containers-v${{ env.WINGLIB_VERSION }}
           files: "*.tgz"
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/fifoqueue-release.yaml
+++ b/.github/workflows/fifoqueue-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          name: Winglib fifoqueue v${{ env.WINGLIB_VERSION }}
+          name: fifoqueue v${{ env.WINGLIB_VERSION }}
           tag_name: fifoqueue-v${{ env.WINGLIB_VERSION }}
           files: "*.tgz"
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/fifoqueue-release.yaml
+++ b/.github/workflows/fifoqueue-release.yaml
@@ -29,9 +29,25 @@ jobs:
       - name: Pack
         run: wing pack
         working-directory: fifoqueue
+      - name: Get package version
+        run: echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
+          "$GITHUB_ENV"
+        working-directory: fifoqueue
       - name: Publish
         run: npm publish --access=public --registry https://registry.npmjs.org --tag
           latest *.tgz
         working-directory: fifoqueue
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          tag: fifoqueue-v${{ env.WINGLIB_VERSION }}
+      - name: GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Winglib fifoqueue v${{ env.WINGLIB_VERSION }}
+          tag_name: fifoqueue-v${{ env.WINGLIB_VERSION }}
+          files: "*.tgz"
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          name: Winglib github v${{ env.WINGLIB_VERSION }}
+          name: github v${{ env.WINGLIB_VERSION }}
           tag_name: github-v${{ env.WINGLIB_VERSION }}
           files: "*.tgz"
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -29,9 +29,25 @@ jobs:
       - name: Pack
         run: wing pack
         working-directory: github
+      - name: Get package version
+        run: echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
+          "$GITHUB_ENV"
+        working-directory: github
       - name: Publish
         run: npm publish --access=public --registry https://registry.npmjs.org --tag
           latest *.tgz
         working-directory: github
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          tag: github-v${{ env.WINGLIB_VERSION }}
+      - name: GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Winglib github v${{ env.WINGLIB_VERSION }}
+          tag_name: github-v${{ env.WINGLIB_VERSION }}
+          files: "*.tgz"
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/postgres-release.yaml
+++ b/.github/workflows/postgres-release.yaml
@@ -29,9 +29,25 @@ jobs:
       - name: Pack
         run: wing pack
         working-directory: postgres
+      - name: Get package version
+        run: echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
+          "$GITHUB_ENV"
+        working-directory: postgres
       - name: Publish
         run: npm publish --access=public --registry https://registry.npmjs.org --tag
           latest *.tgz
         working-directory: postgres
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          tag: postgres-v${{ env.WINGLIB_VERSION }}
+      - name: GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Winglib postgres v${{ env.WINGLIB_VERSION }}
+          tag_name: postgres-v${{ env.WINGLIB_VERSION }}
+          files: "*.tgz"
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/postgres-release.yaml
+++ b/.github/workflows/postgres-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          name: Winglib postgres v${{ env.WINGLIB_VERSION }}
+          name: postgres v${{ env.WINGLIB_VERSION }}
           tag_name: postgres-v${{ env.WINGLIB_VERSION }}
           files: "*.tgz"
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/redis-release.yaml
+++ b/.github/workflows/redis-release.yaml
@@ -29,9 +29,25 @@ jobs:
       - name: Pack
         run: wing pack
         working-directory: redis
+      - name: Get package version
+        run: echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
+          "$GITHUB_ENV"
+        working-directory: redis
       - name: Publish
         run: npm publish --access=public --registry https://registry.npmjs.org --tag
           latest *.tgz
         working-directory: redis
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          tag: redis-v${{ env.WINGLIB_VERSION }}
+      - name: GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Winglib redis v${{ env.WINGLIB_VERSION }}
+          tag_name: redis-v${{ env.WINGLIB_VERSION }}
+          files: "*.tgz"
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/redis-release.yaml
+++ b/.github/workflows/redis-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          name: Winglib redis v${{ env.WINGLIB_VERSION }}
+          name: redis v${{ env.WINGLIB_VERSION }}
           tag_name: redis-v${{ env.WINGLIB_VERSION }}
           files: "*.tgz"
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/websockets-release.yaml
+++ b/.github/workflows/websockets-release.yaml
@@ -29,9 +29,25 @@ jobs:
       - name: Pack
         run: wing pack
         working-directory: websockets
+      - name: Get package version
+        run: echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
+          "$GITHUB_ENV"
+        working-directory: websockets
       - name: Publish
         run: npm publish --access=public --registry https://registry.npmjs.org --tag
           latest *.tgz
         working-directory: websockets
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          tag: websockets-v${{ env.WINGLIB_VERSION }}
+      - name: GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Winglib websockets v${{ env.WINGLIB_VERSION }}
+          tag_name: websockets-v${{ env.WINGLIB_VERSION }}
+          files: "*.tgz"
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/.github/workflows/websockets-release.yaml
+++ b/.github/workflows/websockets-release.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          name: Winglib websockets v${{ env.WINGLIB_VERSION }}
+          name: websockets v${{ env.WINGLIB_VERSION }}
           tag_name: websockets-v${{ env.WINGLIB_VERSION }}
           files: "*.tgz"
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/library.w
+++ b/library.w
@@ -96,7 +96,7 @@ pub class Library {
       name: "GitHub release",
       uses: "softprops/action-gh-release@v1",
       with: {
-        name: "Winglib {base} v\$\{\{ env.WINGLIB_VERSION \}\}",
+        name: "{base} v\$\{\{ env.WINGLIB_VERSION \}\}",
         tag_name: tagName,
         files: "*.tgz",
         token: githubTokenWithAuth,

--- a/library.w
+++ b/library.w
@@ -80,12 +80,15 @@ pub class Library {
       }
     });
 
+    let tagName = "{base}-v\$\{\{ env.WINGLIB_VERSION \}\}";
+    let githubTokenWithAuth = "\$\{\{ secrets.PROJEN_GITHUB_TOKEN }}";
+
     releaseSteps.push({
       name: "Tag commit",
       uses: "tvdias/github-tagger@v0.0.1",
       with: {
-        "repo-token": "\$\{\{ secrets.PROJEN_GITHUB_TOKEN }}",
-        tag: "{base}-v\$\{\{ env.WINGLIB_VERSION \}\}",
+        "repo-token": githubTokenWithAuth,
+        tag: tagName,
       }
     });
 
@@ -94,9 +97,9 @@ pub class Library {
       uses: "softprops/action-gh-release@v1",
       with: {
         name: "Winglib {base} v\$\{\{ env.WINGLIB_VERSION \}\}",
-        tag_name: "{base}-v\$\{\{ env.WINGLIB_VERSION \}\}",
+        tag_name: tagName,
         files: "*.tgz",
-        token: "\$\{\{ secrets.PROJEN_GITHUB_TOKEN }}"
+        token: githubTokenWithAuth,
       },
     });
 

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/postgres",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Postgres support for Wing",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Set up GitHub releases. This will be used to set up a webhook that detects newly released packages from GitHub release events.

Version bumped `postgres` for testing purposes