### PR TITLE
fix: websocket sendMessage url

### DIFF
--- a/websockets/commons/api.w
+++ b/websockets/commons/api.w
@@ -23,7 +23,7 @@ pub interface IWebSocket extends std.IResource {
   /**
    * Sends a message through the WebSocket with inflight handling.
    */
-  inflight sendMessage(connectionId: str, message: str);
+  inflight sendMessage(connectionId: str, message: str): void;
 }
 
 /**

--- a/websockets/lib.test.w
+++ b/websockets/lib.test.w
@@ -39,7 +39,7 @@ wb.onMessage(inflight (id: str, body: str): void => {
 wb.initialize();
 
 interface IWebSocketJS {
-  inflight on(cmd: str, handler: inflight(str):void);
+  inflight on(cmd: str, handler: inflight(str):void): void;
   inflight send(e: str): void;
   inflight close(): void;
 }

--- a/websockets/package-lock.json
+++ b/websockets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/websockets",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/websockets",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.451.0",

--- a/websockets/package.json
+++ b/websockets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/websockets",
   "description": "WebSocket library for Wing",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/websockets/platform/tf-aws.w
+++ b/websockets/platform/tf-aws.w
@@ -145,7 +145,10 @@ pub class WebSocket_tfaws impl awsapi.IAwsWebSocket {
   }
 
   extern "../inflight/websocket.aws.js" static inflight _postToConnection(endpointUrl: str, connectionId: str, message: str): void;
-  pub inflight sendMessage(connectionId: str, message: str) {
-    WebSocket_tfaws._postToConnection(this.url.replace("wss://", "https://"), connectionId, message);
+  pub inflight sendMessage(connectionId: str, message: str): void {
+    // TODO: str.replace does not work when applied to the class property `this.url`, so we need to use a local var for now.
+    let var url = this.url;
+    url = url.replace("wss://", "https://");
+    WebSocket_tfaws._postToConnection(url, connectionId, message);
   }
 }


### PR DESCRIPTION
This PR includes:

- Adding missing void return types.
- Fix URL passed to sendMessage was not being properly built