### PR TITLE
chore: add log statement for test debugging

### DIFF
--- a/containers/containers.test.w
+++ b/containers/containers.test.w
@@ -35,6 +35,7 @@ let httpGet = inflight (url: str?): str => {
 
 test "access public url" {
   let helloBody = httpGet(hello.publicUrl);
+  log(helloBody);
   assert(helloBody.contains(message));
 
   let echoBody = httpGet(echo.publicUrl);

--- a/containers/package-lock.json
+++ b/containers/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/containers",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/containers",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT",
       "dependencies": {
         "@cdktf/provider-aws": "^18.0.5",


### PR DESCRIPTION
This test from `containers` is occasionally failing in CI, but the assertion isn't showing us why. Adding a log statement to help.

Not bumping the library version since releasing a new version isn't necessary here.