### PR TITLE
fix(vite): html transformation

### DIFF
--- a/vite/package.json
+++ b/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/vite",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Wing resource that allows deploying a Vite application to the cloud",
   "repository": {
     "type": "git",

--- a/vite/vite-cli.mjs
+++ b/vite/vite-cli.mjs
@@ -37,7 +37,9 @@ if (command === "dev") {
     })
   );
 
-  server.openBrowser();
+  if (options.openBrowser) {
+    server.openBrowser();
+  }
 } else if (command === "build") {
   const resolvedConfig = await resolveConfig(config);
   console.log(

--- a/vite/vite-plugin.mjs
+++ b/vite/vite-plugin.mjs
@@ -20,12 +20,12 @@ export const plugin = (options) => {
     },
     transformIndexHtml(html) {
       return html.replace(
-        "<head>",
-        `<head>\n    <script>window.${
+        "</head>",
+        `    <script>window.${
           options.publicEnvName
-        }=Object.freeze({meta:Object.freeze({env:${JSON.stringify(
+        }=Object.freeze({env:Object.freeze(${JSON.stringify(
           options.publicEnv
-        )}})});</script>`
+        )})});</script>\n</head>`
       );
     },
     async buildStart() {

--- a/vite/vite.sim.w
+++ b/vite/vite.sim.w
@@ -14,6 +14,7 @@ pub class Vite_sim {
     let cliFilename = Vite_sim.cliFilename();
     let homeEnv = util.env("HOME");
     let pathEnv = util.env("PATH");
+    let openBrowser = util.env("WING_IS_TEST") != "true";
 
     new cloud.Service(inflight () => {
       let url = Vite_sim.dev({
@@ -25,6 +26,7 @@ pub class Vite_sim {
         cliFilename: cliFilename,
         homeEnv: homeEnv,
         pathEnv: pathEnv,
+        openBrowser: openBrowser,
       });
       state.set("url", url);
     });


### PR DESCRIPTION
- Fixes the `wing` object format
- In some cases, such as adding a class to the `<head>` element in the `index.html`, would cause the Vite resource not being able to generate the `wing` environment object at all
- Stop opening the browser when Wing is running tests.
