### PR TITLE
fix(vite): production build uses development variables

### DIFF
--- a/vite/package.json
+++ b/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/vite",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Wing resource that allows deploying a Vite application to the cloud",
   "repository": {
     "type": "git",

--- a/vite/vite.cjs
+++ b/vite/vite.cjs
@@ -16,6 +16,7 @@ exports.build = (options) => {
     env: {
       HOME: options.homeEnv,
       PATH: options.pathEnv,
+      NODE_ENV: "production",
     },
   });
   const output = buffer.stdout.toString().split("\n");


### PR DESCRIPTION
Vite bundles for production when `NODE_ENV=production`, which makes variables like `import.meta.env.DEV` equal to `true` even for production environments.