### PR TITLE
fix(vite): improve `wing` script injection

### DIFF
--- a/vite/package-lock.json
+++ b/vite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/vite",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/vite",
-      "version": "0.0.1",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@cdktf/provider-aws": "^19.6.0",

--- a/vite/package.json
+++ b/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/vite",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Wing resource that allows deploying a Vite application to the cloud",
   "repository": {
     "type": "git",

--- a/vite/vite-plugin.mjs
+++ b/vite/vite-plugin.mjs
@@ -19,14 +19,20 @@ export const plugin = (options) => {
       context.root = config.root;
     },
     transformIndexHtml(html) {
-      return html.replace(
-        "</head>",
-        `    <script>window.${
-          options.publicEnvName
-        }=Object.freeze({env:Object.freeze(${JSON.stringify(
-          options.publicEnv
-        )})});</script>\n</head>`
-      );
+      return {
+        html,
+        tags: [
+          {
+            tag: "script",
+            children: `window.${
+              options.publicEnvName
+            }=Object.freeze({env:Object.freeze(${JSON.stringify(
+              options.publicEnv
+            )})});`,
+            injectTo: "head-prepend",
+          },
+        ],
+      };
     },
     async buildStart() {
       if (!options.generateTypeDefinitions) {

--- a/vite/vite.tf-aws.w
+++ b/vite/vite.tf-aws.w
@@ -48,7 +48,7 @@ pub class Vite_tf_aws {
       let filename = fs.absolute("{distDir}/{file}");
       let var cacheControl = "public, max-age={1m.seconds}";
       if key.startsWith("/assets/") {
-        cacheControl = "public, max-age={1y.seconds}";
+        cacheControl = "public, max-age={1y.seconds}, immutable";
       }
       if file == "index.html" {
         new aws.s3Object.S3Object(
@@ -121,8 +121,8 @@ pub class Vite_tf_aws {
         },
         viewerProtocolPolicy: "redirect-to-https",
         compress: true,
-        minTtl: 5m.seconds,
-        defaultTtl: 5m.seconds,
+        minTtl: 1m.seconds,
+        defaultTtl: 1m.seconds,
         maxTtl: 1y.seconds,
       },
       priceClass: "PriceClass_100",


### PR DESCRIPTION
- Improve `wing` object script injection by using Vite's tags API
- Add the `immutable` cache directive to assets
- Lower the default cache time for non-assets to 1m (eg, the `index.html` file)