### PR TITLE
chore: update fifo-queue version

### DIFF
--- a/fifoqueue/package.json
+++ b/fifoqueue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/fifoqueue",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A wing library to work with FIFO (first-in first-out) Queues",
   "author": {
     "name": "Elad Cohen",


### PR DESCRIPTION
I forgot to update this one in my last PR