### PR TITLE
fix(containers): ensure containers are destroyed when wing console is interrupted

### DIFF
--- a/containers/package-lock.json
+++ b/containers/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/containers",
-  "version": "0.0.21",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/containers",
-      "version": "0.0.21",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
         "@cdktf/provider-aws": "^18.0.5",

--- a/containers/package.json
+++ b/containers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/containers",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Container support for Wing",
   "repository": {
     "type": "git",

--- a/containers/workload.sim.w
+++ b/containers/workload.sim.w
@@ -18,7 +18,7 @@ pub class Workload_sim {
   imageTag: str;
   public: bool;
   state: sim.State;
-  
+
   new(props: api.WorkloadProps) {
     this.appDir = utils.entrypointDir(this);
     this.props = props;
@@ -51,108 +51,118 @@ pub class Workload_sim {
     }
 
     let s = new cloud.Service(inflight () => {
-      this.start();
-      return () => { this.stop(); };
-    });
+      log("starting workload...");
 
-    std.Node.of(s).hidden = true;
-    std.Node.of(this.state).hidden = true;
-  }
+      let opts = this.props;
 
-  inflight start(): void {
-    log("starting workload...");
-
-    let opts = this.props;
-
-    // if this a reference to a local directory, build the image from a docker file
-    if utils.isPathInflight(opts.image) {
-      // check if the image is already built
-      try {
-        utils.shell("docker", ["inspect", this.imageTag]);
-        log("image {this.imageTag} already exists");
-      } catch {
-        log("building locally from {opts.image} and tagging {this.imageTag}...");
-        utils.shell("docker", ["build", "-t", this.imageTag, opts.image], this.appDir);
-      }
-    } else {
-      try {
-        utils.shell("docker", ["inspect", this.imageTag]);
-        log("image {this.imageTag} already exists");
-      } catch {
-        log("pulling {this.imageTag}");
-        utils.shell("docker", ["pull", this.imageTag]);
-      }
-    }
-
-    // start the new container
-    let dockerRun = MutArray<str>[];
-    dockerRun.push("run");
-    dockerRun.push("--detach");
-
-    if let port = opts.port {
-      dockerRun.push("-p");
-      dockerRun.push("{port}");
-    }
-
-    if let env = opts.env {
-      if env.size() > 0 {
-        dockerRun.push("-e");
-        for k in env.keys() {
-          dockerRun.push("{k}={env.get(k)!}");
+      // if this a reference to a local directory, build the image from a docker file
+      if utils.isPathInflight(opts.image) {
+        // check if the image is already built
+        try {
+          utils.shell("docker", ["inspect", this.imageTag]);
+          log("image {this.imageTag} already exists");
+        } catch {
+          log("building locally from {opts.image} and tagging {this.imageTag}...");
+          utils.shell("docker", ["build", "-t", this.imageTag, opts.image], this.appDir);
+        }
+      } else {
+        try {
+          utils.shell("docker", ["inspect", this.imageTag]);
+          log("image {this.imageTag} already exists");
+        } catch {
+          log("pulling {this.imageTag}");
+          utils.shell("docker", ["pull", this.imageTag]);
         }
       }
-    }
 
-    dockerRun.push(this.imageTag);
+      // start the new container
+      let dockerRun = MutArray<str>[];
+      dockerRun.push("run");
+      dockerRun.push("--detach");
+      dockerRun.push("--rm");
 
-    if let runArgs = this.props.args {
-      for a in runArgs {
-        dockerRun.push(a);
-      }
-    }
+      let name = util.uuidv4();
+      dockerRun.push("--name", name);
 
-    log("starting container from image {this.imageTag}");
-    log("docker {dockerRun.join(" ")}");
-    let containerId = utils.shell("docker", dockerRun.copy()).trim();
-    this.state.set(this.containerIdKey, containerId);
-
-    log("containerId={containerId}");
-
-    let out = Json.parse(utils.shell("docker", ["inspect", containerId]));
-
-    if let port = opts.port {
-      let hostPort = out.tryGetAt(0)?.tryGet("NetworkSettings")?.tryGet("Ports")?.tryGet("{port}/tcp")?.tryGetAt(0)?.tryGet("HostPort")?.tryAsStr();
-      if !hostPort? {
-        throw "Container does not listen to port {port}";
+      if let port = opts.port {
+        dockerRun.push("-p");
+        dockerRun.push("{port}");
       }
 
-      let publicUrl = "http://localhost:{hostPort!}";
-
-      if let k = this.publicUrlKey {
-        this.state.set(k, publicUrl);
-      }
-
-      if let k = this.internalUrlKey {
-        this.state.set(k, "http://host.docker.internal:{hostPort!}");
-      }
-
-      if let readiness = opts.readiness {
-        let readinessUrl = "{publicUrl}{readiness}";
-        log("waiting for container to be ready: {readinessUrl}...");
-        util.waitUntil(inflight () => {
-          try {
-            return http.get(readinessUrl).ok;
-          } catch {
-            return false;
+      if let env = opts.env {
+        if env.size() > 0 {
+          dockerRun.push("-e");
+          for k in env.keys() {
+            dockerRun.push("{k}={env.get(k)!}");
           }
-        }, interval: 0.1s);
+        }
       }
-    }
-  }
 
-  inflight stop() {
-    let containerId = this.state.get(this.containerIdKey).asStr();
-    log("stopping container {containerId}");
-    utils.shell("docker", ["rm", "-f", containerId]);
+      dockerRun.push(this.imageTag);
+
+      if let runArgs = this.props.args {
+        for a in runArgs {
+          dockerRun.push(a);
+        }
+      }
+
+      log("starting container from image {this.imageTag}");
+      log("docker {dockerRun.join(" ")}");
+      utils.shell("docker", dockerRun.copy());
+      this.state.set(this.containerIdKey, name);
+
+      log("containerName={name}");
+
+      return () => {
+        utils.shell("docker", ["rm", "-f", name]);
+       };
+    });
+    std.Node.of(s).hidden = true;
+
+    let s2 = new cloud.Service(inflight () => {
+      let name = this.state.get(this.containerIdKey).asStr();
+      let opts = this.props;
+      let var out: Json? = nil;
+      util.waitUntil(inflight () => {
+        try {
+          out = Json.parse(utils.shell("docker", ["inspect", name]));
+          return true;
+        } catch {
+          return false;
+        }
+      }, interval: 0.1s);
+
+      if let port = opts.port {
+        let hostPort = out?.tryGetAt(0)?.tryGet("NetworkSettings")?.tryGet("Ports")?.tryGet("{port}/tcp")?.tryGetAt(0)?.tryGet("HostPort")?.tryAsStr();
+        if !hostPort? {
+          throw "Container does not listen to port {port}";
+        }
+
+        let publicUrl = "http://localhost:{hostPort!}";
+
+        if let k = this.publicUrlKey {
+          this.state.set(k, publicUrl);
+        }
+
+        if let k = this.internalUrlKey {
+          this.state.set(k, "http://host.docker.internal:{hostPort!}");
+        }
+
+        if let readiness = opts.readiness {
+          let readinessUrl = "{publicUrl}{readiness}";
+          log("waiting for container to be ready: {readinessUrl}...");
+          util.waitUntil(inflight () => {
+            try {
+              return http.get(readinessUrl).ok;
+            } catch {
+              return false;
+            }
+          }, interval: 0.1s);
+        }
+      }
+    }) as "Port Retrieval";
+    std.Node.of(s2).hidden = true;
+
+    std.Node.of(this.state).hidden = true;
   }
 }

--- a/containers/workload.sim.w
+++ b/containers/workload.sim.w
@@ -50,7 +50,7 @@ pub class Workload_sim {
       this.internalUrlKey = key;
     }
 
-    let s = new cloud.Service(inflight () => {
+    let containerService = new cloud.Service(inflight () => {
       log("starting workload...");
 
       let opts = this.props;
@@ -116,10 +116,10 @@ pub class Workload_sim {
       return () => {
         utils.shell("docker", ["rm", "-f", name]);
        };
-    });
-    std.Node.of(s).hidden = true;
+    }) as "ContainerService";
+    std.Node.of(containerService).hidden = true;
 
-    let s2 = new cloud.Service(inflight () => {
+    let readinessService = new cloud.Service(inflight () => {
       let name = this.state.get(this.containerIdKey).asStr();
       let opts = this.props;
       let var out: Json? = nil;
@@ -160,8 +160,8 @@ pub class Workload_sim {
           }, interval: 0.1s);
         }
       }
-    }) as "Port Retrieval";
-    std.Node.of(s2).hidden = true;
+    }) as "ReadinessService";
+    std.Node.of(readinessService).hidden = true;
 
     std.Node.of(this.state).hidden = true;
   }


### PR DESCRIPTION
- Use `docker --rm --detach` along with a random container name
- Explicitly remove the container during `cloud.Service` destroy callback