### PR TITLE
chore(dynamodb): execute tests in serial

### DIFF
--- a/.github/workflows/dynamodb-pull.yaml
+++ b/.github/workflows/dynamodb-pull.yaml
@@ -22,7 +22,10 @@ jobs:
         run: npm install --include=dev
         working-directory: dynamodb
       - name: Test
-        run: wing test
+        run: |
+          for testfile in tests/*.test.w; do
+            wing test "$testfile"
+          done
         working-directory: dynamodb
       - name: Pack
         run: wing pack

--- a/.github/workflows/dynamodb-release.yaml
+++ b/.github/workflows/dynamodb-release.yaml
@@ -25,17 +25,22 @@ jobs:
         run: npm install --include=dev
         working-directory: dynamodb
       - name: Test
-        run: wing test
+        run: |
+          for testfile in tests/*.test.w; do
+            wing test "$testfile"
+          done
         working-directory: dynamodb
       - name: Pack
         run: wing pack
         working-directory: dynamodb
       - name: Get package version
-        run: echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
+        run:
+          echo WINGLIB_VERSION=$(node -p "require('./package.json').version") >>
           "$GITHUB_ENV"
         working-directory: dynamodb
       - name: Publish
-        run: npm publish --access=public --registry https://registry.npmjs.org --tag
+        run:
+          npm publish --access=public --registry https://registry.npmjs.org --tag
           latest *.tgz
         working-directory: dynamodb
         env:


### PR DESCRIPTION
The Wing test runner will keep all docker containers while running the tests, which amounts to ~10 containers. I believe the CI runner runs out of memory because of this.