### PR TITLE
fix(checks): latest does not check for nil

### DIFF
--- a/checks/package.json
+++ b/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/checks",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Cloud checks",
   "publishConfig": {
     "access": "public",

--- a/checks/results.w
+++ b/checks/results.w
@@ -56,7 +56,10 @@ pub class Results {
   pub inflight latest(checkid: str): CheckResult? {
     let key = this.makeLatestKey(checkid);
     let s = this.bucket.tryGetJson(key);
-    return CheckResult.fromJson(s);
+    if let s = s {
+      return CheckResult.fromJson(s);
+    }
+    return nil;
   }
 
   inflight makeKey(checkid: str, key: str): str {


### PR DESCRIPTION
Maybe is a smell that we need `Struct.tryFromJson` but the core issue is the undefined object passed validation, which is surprising to me, but non the less there is some cleanup needed in Struct.fromJson since I made the changes to only return back the fields that match, and not the whole object.