### PR TITLE
feat(dynamodb)!: api tweaks

### DIFF
--- a/dynamodb/README.md
+++ b/dynamodb/README.md
@@ -51,9 +51,16 @@ test "put and query" {
 In case you want to instantiate your own DynamoDB SDK, you can get the connection details like this:
 
 ```wing
-let connection = table.connection();
-connection.endpoint;
-connection.tableName;
+table.connection.clientConfig.endpoint;
+table.connection.clientConfig.credentials;
+table.connection.clientConfig.region;
+table.connection.tableName;
+```
+
+So you can use the AWS SDK DynamoDB client like this:
+
+```js
+new DynamoDB(table.connection.clientConfig);
 ```
 
 ## License

--- a/dynamodb/dynamodb-types.w
+++ b/dynamodb/dynamodb-types.w
@@ -181,9 +181,20 @@ pub struct TableProps {
   pointInTimeRecovery: bool?;
 }
 
+pub struct Credentials {
+  accessKeyId: str;
+  secretAccessKey: str;
+}
+
+pub struct ClientConfig {
+  endpoint: str;
+  region: str;
+  credentials: Credentials;
+}
+
 pub struct Connection {
-  endpoint: str?;
   tableName: str;
+  clientConfig: ClientConfig?;
 }
 
 pub interface IClient {
@@ -196,6 +207,5 @@ pub interface IClient {
 }
 
 pub interface ITable extends IClient {
-  connection(): Connection;
   setStreamConsumer(handler: inflight (StreamRecord): void, options: StreamConsumerOptions?): void;
 }

--- a/dynamodb/dynamodb.extern.d.ts
+++ b/dynamodb/dynamodb.extern.d.ts
@@ -1,12 +1,16 @@
 export default interface extern {
-  createClient: (options: CreateClientOptions) => Promise<Client$Inflight>,
+  createClient: (options: ClientConfig) => Promise<Client$Inflight>,
   createDocumentClient: (options?: (CreateDocumentClientOptions) | undefined) => Promise<DocumentClient$Inflight>,
   getPort: () => Promise<number>,
   processRecordsAsync: (endpoint: string, tableName: string, handler: (arg0: StreamRecord) => Promise<void>, options?: (StreamConsumerOptions) | undefined) => Promise<void>,
   unmarshall: (item: Readonly<any>, options?: (Readonly<any>) | undefined) => Promise<Readonly<any>>,
 }
-export interface CreateClientOptions {
-  readonly credentials: Readonly<any>;
+export interface Credentials {
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+}
+export interface ClientConfig {
+  readonly credentials: Credentials;
   readonly endpoint: string;
   readonly region: string;
 }
@@ -20,7 +24,7 @@ export interface Credentials {
   readonly secretAccessKey: string;
 }
 export interface CreateDocumentClientOptions {
-  readonly credentials?: (Credentials) | undefined;
+  readonly credentials?: (Credentials1) | undefined;
   readonly endpoint?: (string) | undefined;
   readonly region?: (string) | undefined;
 }

--- a/dynamodb/dynamodb.tf-aws.w
+++ b/dynamodb/dynamodb.tf-aws.w
@@ -40,8 +40,10 @@ class Util {
 }
 
 pub class Table_tfaws impl dynamodb_types.ITable {
-  tableName: str;
+  pub tableName: str;
   table: tfaws.dynamodbTable.DynamodbTable;
+
+  pub connection: dynamodb_types.Connection;
 
   new(props: dynamodb_types.TableProps) {
     this.table = new tfaws.dynamodbTable.DynamodbTable({
@@ -50,7 +52,7 @@ pub class Table_tfaws impl dynamodb_types.ITable {
       // - Get rid of the initial "root/Default/Default/" part (21 characters)
       // - Make room for the last 8 digits of the address (9 characters including hyphen). 255 is the maximum length of an AWS resource name
       // - Add the last 8 digits of the address
-      name: "{this.node.path.replaceAll("/", "-").substring(21, (255+21)-9)}-{this.node.addr.substring(42-8)}",
+      name: props.name ?? "{this.node.path.replaceAll("/", "-").substring(21, (255+21)-9)}-{this.node.addr.substring(42-8)}",
       attribute: props.attributes,
       hashKey: props.hashKey,
       rangeKey: props.rangeKey,
@@ -63,13 +65,7 @@ pub class Table_tfaws impl dynamodb_types.ITable {
     });
 
     this.tableName = this.table.name;
-  }
-
-  pub connection(): dynamodb_types.Connection {
-    return {
-      endpoint: nil,
-      tableName: this.tableName,
-    };
+    this.connection = { tableName: this.tableName };
   }
 
   pub setStreamConsumer(handler: inflight (dynamodb_types.StreamRecord): void, options: dynamodb_types.StreamConsumerOptions?) {

--- a/dynamodb/dynamodb.w
+++ b/dynamodb/dynamodb.w
@@ -7,19 +7,26 @@ bring "./dynamodb.tf-aws.w" as dynamodb_tfaws;
 pub class Table impl dynamodb_types.ITable {
   implementation: dynamodb_types.ITable;
 
+  pub connection: dynamodb_types.Connection;
+  pub tableName: str;
+
   new(props: dynamodb_types.TableProps) {
     let target = util.env("WING_TARGET");
     if target == "sim" {
-      this.implementation = new dynamodb_sim.Table_sim(props);
+      let sim = new dynamodb_sim.Table_sim(props);
+      this.connection = sim.connection;
+      this.tableName = sim.tableName;
+      this.implementation = sim;
+
     } elif target == "tf-aws" {
-      this.implementation = new dynamodb_tfaws.Table_tfaws(props);
+      let tfaws = new dynamodb_tfaws.Table_tfaws(props);
+      this.connection = tfaws.connection;
+      this.tableName = tfaws.tableName;
+      this.implementation = tfaws;
     } else {
       throw "Unsupported target {target}";
     }
-  }
 
-  pub connection(): dynamodb_types.Connection {
-    return this.implementation.connection();
   }
 
   pub setStreamConsumer(handler: inflight (dynamodb_types.StreamRecord): void) {

--- a/dynamodb/package-lock.json
+++ b/dynamodb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/dynamodb",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/dynamodb",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "devDependencies": {
         "@cdktf/provider-helm": "^10.0.0",

--- a/dynamodb/tests/connection.test.w
+++ b/dynamodb/tests/connection.test.w
@@ -1,0 +1,29 @@
+bring cloud;
+bring util;
+bring expect;
+bring "../dynamodb.w" as dynamodb;
+
+let table = new dynamodb.Table(
+  name: "my-table-name",
+  attributes: [ { name: "id", type: "S" } ],
+  hashKey: "id"
+);
+
+if util.env("WING_TARGET") == "sim" {
+
+  test "sim returns localhost" {
+    expect.equal(table.connection.tableName, "my-table-name");
+    expect.equal(table.connection.clientConfig?.credentials?.accessKeyId, "local");
+    expect.equal(table.connection.clientConfig?.credentials?.secretAccessKey, "local");
+    expect.equal(table.connection.clientConfig?.region, "local");
+    assert(table.connection.clientConfig?.endpoint?.startsWith("http://localhost:")!);
+  }
+
+} else {
+
+  test "non-sim returns the table name and nil" {
+    expect.equal(table.connection.tableName, "my-table-name");
+    expect.equal(table.connection.clientConfig, nil);
+  }
+
+}

--- a/dynamodb/tests/name.test.w
+++ b/dynamodb/tests/name.test.w
@@ -1,0 +1,24 @@
+bring cloud;
+bring util;
+bring expect;
+bring "../dynamodb.w" as dynamodb;
+
+let table = new dynamodb.Table(
+  name: "my-table-name",
+  attributes: [ { name: "id", type: "S" } ],
+  hashKey: "id"
+) as "explicit_name";
+
+let table2 = new dynamodb.Table(
+  attributes: [ { name: "id", type: "S" } ],
+  hashKey: "id"
+) as "implicit_name";
+
+test "explicit table name" {
+  expect.equal(table.tableName, "my-table-name");
+}
+
+test "implicit table name" {
+  log(table.tableName);
+  assert(table.tableName.length > 0);
+}


### PR DESCRIPTION
## `table.connection`

`table.connection` now includes `clientConfig` instead of just `endpoint`, so it can be used to create an AWS SDK client without any hacks.

I also changed it from a method to a property, so it can be lifted across inflight.

## `table.tableName`

Added a `tableName` property with the name of the table.

Found a bug in `tf-aws` where `name` was not respected.

Tested on AWS.

BREAKING CHANGE: `table.connection()` (method) is now `table.connection` (property). The `connection.endpoint` attribute is now `connection.clientConfig.endpoint`.