### PR TITLE
fix(dynamodb): events of type "insert" not processed when multiple tables are present

### DIFF
--- a/dynamodb/dynamodb.sim.w
+++ b/dynamodb/dynamodb.sim.w
@@ -50,9 +50,10 @@ pub class Table_sim impl dynamodb_types.ITable {
   pub connection: dynamodb_types.Connection;
 
   new(props: dynamodb_types.TableProps) {
-    // Ideally, we would reuse the same host (and container) for all tables in the same stack,
-    // but there seems to be a bug somewhere that prevents INSERT events from being processed
-    // where there's more than one table in the application.
+    // Ideally, we would reuse the same host (and container) for all tables in
+    // the same application, but there seems to be a bug somewhere that prevents
+    // INSERT events from being processed when there's more than one table in
+    // the application.
     //
     // So, instead of `this.host = Host.of(this);`, we just:
     this.host = new Host();

--- a/dynamodb/dynamodb.sim.w
+++ b/dynamodb/dynamodb.sim.w
@@ -50,7 +50,12 @@ pub class Table_sim impl dynamodb_types.ITable {
   pub connection: dynamodb_types.Connection;
 
   new(props: dynamodb_types.TableProps) {
-    this.host = Host.of(this);
+    // Ideally, we would reuse the same host (and container) for all tables in the same stack,
+    // but there seems to be a bug somewhere that prevents INSERT events from being processed
+    // where there's more than one table in the application.
+    //
+    // So, instead of `this.host = Host.of(this);`, we just:
+    this.host = new Host();
 
     let tableName = props.name ?? this.node.addr;
     let state = new sim.State();


### PR DESCRIPTION
There seems to be a bug where INSERT events aren't processed by the stream consumer (only for apps that have more than one table).

The workaround stops reusing the same host (and container) and instead creates one container per table.