### PR TITLE
fix(dynamodb): cannot reuse container since table already exists

### DIFF
--- a/dynamodb/dynamodb.sim.w
+++ b/dynamodb/dynamodb.sim.w
@@ -139,6 +139,10 @@ pub class Table_sim impl dynamodb_types.ITable {
         return  nil;
       })();
 
+      // delete the table if it already exists
+      try { client.deleteTable({ TableName: tableName }); } 
+      catch e { }
+
       util.waitUntil(() => {
         try {
           client.createTable({

--- a/dynamodb/dynamodb.sim.w
+++ b/dynamodb/dynamodb.sim.w
@@ -139,7 +139,7 @@ pub class Table_sim impl dynamodb_types.ITable {
         return  nil;
       })();
 
-      // delete the table if it already exists
+      // delete the table if it already exists because we might be reusing the container
       try { client.deleteTable({ TableName: tableName }); } 
       catch e { }
 

--- a/dynamodb/package.json
+++ b/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/dynamodb",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "DynamoDB library for Wing",
   "author": {
     "name": "Cristian Pallarés",


### PR DESCRIPTION
Now since the container might be reused across simulator updates, we need to make sure we clean up the table before it's being created.

I've tested this manually because I am not sure how to test this.