### PR TITLE
fix(dynamodb): update table ttl after table is ready

### DIFF
--- a/dynamodb/dynamodb.sim.w
+++ b/dynamodb/dynamodb.sim.w
@@ -158,16 +158,6 @@ pub class Table_sim impl dynamodb_types.ITable {
             },
           });
 
-          if let timeToLiveAttribute = props.timeToLiveAttribute {
-            client.updateTimeToLive({
-              TableName: tableName,
-              TimeToLiveSpecification: {
-                AttributeName: timeToLiveAttribute,
-                Enabled: true,
-              },
-            });
-          }
-
           // Wait until we can describe the table. This is
           // to ensure that the table is ready to be used.
           util.waitUntil(() => {
@@ -180,6 +170,16 @@ pub class Table_sim impl dynamodb_types.ITable {
               return false;
             }
           });
+
+          if let timeToLiveAttribute = props.timeToLiveAttribute {
+            client.updateTimeToLive({
+              TableName: tableName,
+              TimeToLiveSpecification: {
+                AttributeName: timeToLiveAttribute,
+                Enabled: true,
+              },
+            });
+          }
 
           state.set("tableName", tableName);
           return true;

--- a/dynamodb/package-lock.json
+++ b/dynamodb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/dynamodb",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/dynamodb",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-dynamodb": "^3.461.0",

--- a/dynamodb/package.json
+++ b/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/dynamodb",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "DynamoDB library for Wing",
   "author": {
     "name": "Cristian Pallarés",


### PR DESCRIPTION
Previously, the simulator target would try to update the TTL of the table before waiting for the table to be ready.