### PR TITLE
feat(react): add custom domain

### DIFF
--- a/react/api.w
+++ b/react/api.w
@@ -16,6 +16,8 @@ pub struct AppPros {
   buildCommand: str?;
   // In sim, if `true` - will use the start command, and if `false` - the build command.
   useBuildCommand: bool?;
+  // The website's custom domain object.
+  domain: cloud.Domain?;
 }
 
 pub interface IApp {

--- a/react/package.json
+++ b/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/react",
   "description": "React library for Wing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "Meir Elbaz",
     "email": "maornet@gmail.com"

--- a/react/sim.w
+++ b/react/sim.w
@@ -17,8 +17,6 @@ pub class AppSim extends api.AppBase impl api.IApp {
     this.url = state.token("url");
 
     let service = new cloud.Service(inflight () => {
-      // TODO: solution for test environment
-      // let var port = utils.Utils.getPort();
       let port = props.localPort ?? 3001;
 
       state.set("url", "http://localhost:{port}");

--- a/react/tf-aws.w
+++ b/react/tf-aws.w
@@ -20,6 +20,7 @@ pub class AppTfAws extends api.AppBase impl api.IApp {
     this.website = new cloud.Website(
       path: this.buildDir,
       errorDocument: "index.html",
+      domain: this.props.domain,
     );
   }
 

--- a/react/utils.extern.d.ts
+++ b/react/utils.extern.d.ts
@@ -1,6 +1,5 @@
 export default interface extern {
   exec: (command: string, env: Record<string, string>, cwd: string) => Promise<() => Promise<void>>,
   execSync: (command: string, env: Record<string, string>, cwd: string) => void,
-  getPort: () => Promise<number>,
   serveStaticFiles: (path: string, port: number) => Promise<() => Promise<void>>,
 }

--- a/react/utils.js
+++ b/react/utils.js
@@ -2,11 +2,8 @@ const child_process = require("node:child_process");
 const http = require("node:http");
 
 const finalhandler = require("finalhandler");
-const getPort = require("get-port");
 const serveStatic = require("serve-static");
 const treeKill = require("tree-kill");
-
-exports.getPort = getPort;
 
 exports.exec = (command, env, cwd) => {
   process.env.NODE_NO_WARNINGS = "1"; // disable deprecation warnings

--- a/react/utils.w
+++ b/react/utils.w
@@ -1,5 +1,4 @@
 pub class Utils {
-  pub static extern "./utils.js" inflight getPort(): num;
   pub static extern "./utils.js" inflight exec(command: str, env: MutMap<str>, cwd: str): inflight(): void;
   pub static extern "./utils.js" inflight serveStaticFiles(path: str, port: num): inflight (): void;
   pub static extern "./utils.js" execSync(command: str, env: MutMap<str>, cwd: str): void;


### PR DESCRIPTION
Implement of https://github.com/winglang/wing/issues/6178

I also deleted `get-port` from the code, it causes a compilation error (in addition to not being used at the moment):

```
Error: require() of ES Module /Users/meir/Documents/GitHub/winglibs2/react/node_modules/get-port/index.js from /Users/meir/Documents/GitHub/winglibs2/react/utils.js not supported.
Instead change the require of index.js in /Users/meir/Documents/GitHub/winglibs2/react/utils.js to a dynamic import() which is available in all CommonJS modules.
```