### PR TITLE
feat(tsoa)!: new lift API

### DIFF
--- a/tsoa/README.md
+++ b/tsoa/README.md
@@ -29,7 +29,7 @@ It is also possible to use Wing resources from the TS code
 
 ```js
 let bucket = new cloud.Bucket();
-service.lift("bucket", bucket, allow: ["put"]);
+service.lift(bucket, id: "bucket", allow: ["put"]);
 ```
 
 ```ts

--- a/tsoa/README.md
+++ b/tsoa/README.md
@@ -29,12 +29,12 @@ It is also possible to use Wing resources from the TS code
 
 ```js
 let bucket = new cloud.Bucket();
-service.liftClient("bucket", bucket, ["put"]);
+service.lift("bucket", bucket, allow: ["put"]);
 ```
 
 ```ts
 // someController.ts ...
-import { getClient } from "@winglibs/tsoa/clients.js";
+import { lifted } from "@winglibs/tsoa/clients.js";
 
 @Get("{userId}")
 public async getUser(
@@ -42,8 +42,8 @@ public async getUser(
   @Request() request: Req,
   @Query() name?: string,
 ): Promise<User> {
-  let bucket = getClient(request, "bucket");
-  bucket.put(userId.toString(), name ?? "not-a-name");
+  let bucket = lifted("bucket");
+  await bucket.put(userId.toString(), name ?? "not-a-name");
 
   return  {
     id :userId,

--- a/tsoa/app-aws.js
+++ b/tsoa/app-aws.js
@@ -1,12 +1,12 @@
 const express = require("express");
-const { setClients } = require("./clients");
+const { setLifted } = require("./clients");
 const serverlessHttp = require("serverless-http");
 
 var _clients = undefined;
 
 const app = express();
 app.use((req, res, next) => {
-  setClients(req, _clients);
+  setLifted(_clients);
   next();
 });
 app.use(

--- a/tsoa/app.js
+++ b/tsoa/app.js
@@ -1,11 +1,11 @@
 const express = require("express");
-const { setClients } = require("./clients");
+const { setLifted } = require("./clients");
 
 exports.runServer = async (routes, clients) => {
   const app = express();
 
   app.use((req, res, next) => {
-    setClients(req, clients);
+    setLifted(clients);
     next();
   });
 

--- a/tsoa/clients.d.ts
+++ b/tsoa/clients.d.ts
@@ -1,5 +1,3 @@
-import { Request } from 'express';
+declare const lifted: (id: string) => any;
 
-declare const getClient: (req: Request, id: string) => any;
-
-export { getClient };
+export { lifted };

--- a/tsoa/clients.js
+++ b/tsoa/clients.js
@@ -1,20 +1,22 @@
-module.exports.getClients = (req) => {
-  return req.__wing_clients;
-};
+const { AsyncLocalStorage } = require("node:async_hooks");
+
+// this might run in a different context in sim
+const asyncLocalStorage = new AsyncLocalStorage();
+global.asyncLocalStorage = asyncLocalStorage;
 
 /**
  * Get a Wing client from the request object.
- * @param {Object} req - The request object.
  * @param {string} id - The client Id.
  * @returns {Object} - The requested client.
  */
-module.exports.getClient = (req, id) => {
-  if (!req.__wing_clients || !req.__wing_clients[id]) {
+module.exports.lifted = (id) => {
+  const clients = global.asyncLocalStorage.getStore();
+  if (!clients || !clients[id]) {
     throw new Error(`Wing client ${id} not found`);
   }
-  return req.__wing_clients[id];
+  return clients[id];
 };
 
-module.exports.setClients = (req, clients) => {
-  req.__wing_clients = clients;
+module.exports.setLifted = (clients) => {
+  global.asyncLocalStorage.enterWith(clients);
 };

--- a/tsoa/lib.w
+++ b/tsoa/lib.w
@@ -29,7 +29,7 @@ pub class Service impl types.IService {
     new cloud.Endpoint(this.url);
   }
 
-  pub liftClient(id: str, client: std.Resource, ops: Array<str>) {
-    this.inner.liftClient(id, client, ops);
+  pub lift(id: str, client: std.Resource, ops: types.LiftOptions) {
+    this.inner.lift(id, client, ops);
   }
 }

--- a/tsoa/lib.w
+++ b/tsoa/lib.w
@@ -29,7 +29,7 @@ pub class Service impl types.IService {
     new cloud.Endpoint(this.url);
   }
 
-  pub lift(id: str, client: std.Resource, ops: types.LiftOptions) {
-    this.inner.lift(id, client, ops);
+  pub lift(client: std.Resource, ops: types.LiftOptions) {
+    this.inner.lift(client, ops);
   }
 }

--- a/tsoa/package-lock.json
+++ b/tsoa/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/tsoa",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/tsoa",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "license": "MIT",
       "peerDependencies": {
         "@cdktf/provider-aws": "^19.13.0",

--- a/tsoa/package.json
+++ b/tsoa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/tsoa",
   "description": "TSOA library for Wing",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "author": {
     "email": "eyalk@wing.cloud",
     "name": "Eyal Keren"

--- a/tsoa/sim.w
+++ b/tsoa/sim.w
@@ -62,8 +62,8 @@ pub class Service_sim impl types.IService {
     }, link: true);
   }
 
-  pub liftClient(id: str, client: std.Resource, ops: Array<str>) {
-    client.onLift(this.service, ops);
+  pub lift(id: str, client: std.Resource, ops: types.LiftOptions) {
+    client.onLift(this.service, ops.allow);
     this.clients.set(id, client);
   }
 

--- a/tsoa/sim.w
+++ b/tsoa/sim.w
@@ -62,9 +62,9 @@ pub class Service_sim impl types.IService {
     }, link: true);
   }
 
-  pub lift(id: str, client: std.Resource, ops: types.LiftOptions) {
+  pub lift(client: std.Resource, ops: types.LiftOptions) {
     client.onLift(this.service, ops.allow);
-    this.clients.set(id, client);
+    this.clients.set(ops.id, client);
   }
 
   extern "./lib.js" inflight static startService(options: types.StartServiceOptions): StartResponse;

--- a/tsoa/test-assets/usersController.ts
+++ b/tsoa/test-assets/usersController.ts
@@ -10,7 +10,7 @@ import {
 	Request,
 } from "tsoa";
 
-import { getClient } from "../clients.js";
+import { lifted } from "../clients.js";
 import { Request as Req } from "express";
 
 interface User {
@@ -36,7 +36,7 @@ export class UsersController extends Controller {
 		@Request() request: Req,
 		@Query() name?: string,
 	): Promise<User> {
-		let bucket = getClient(request, "bucket");
+		let bucket = lifted("bucket");
 		await bucket.put(userId.toString(), name ?? "not-a-name");
 
     return  {

--- a/tsoa/test/lib.test.w
+++ b/tsoa/test/lib.test.w
@@ -15,7 +15,7 @@ let service = new tsoa.Service(
   routesDir: "../test-assets/build",
 );
 
-service.liftClient("bucket", bucket, ["put"]);
+service.lift("bucket", bucket, allow: ["put"]);
 
 test "will start tsoa service" {
   let res = http.get("{service.url}/users/123?name=stam");

--- a/tsoa/test/lib.test.w
+++ b/tsoa/test/lib.test.w
@@ -15,7 +15,7 @@ let service = new tsoa.Service(
   routesDir: "../test-assets/build",
 );
 
-service.lift("bucket", bucket, allow: ["put"]);
+service.lift(bucket, id: "bucket", allow: ["put"]);
 
 test "will start tsoa service" {
   let res = http.get("{service.url}/users/123?name=stam");

--- a/tsoa/tfaws.w
+++ b/tsoa/tfaws.w
@@ -147,8 +147,8 @@ pub class Service_tfaws impl types.IService {
     this.url = deploy.invokeUrl;
   }
 
-  pub liftClient(id: str, client: std.Resource, ops: Array<str>) {
-    client.onLift(this.func.fn, ops);
+  pub lift(id: str, client: std.Resource, ops: types.LiftOptions) {
+    client.onLift(this.func.fn, ops.allow);
     this.clients.set(id, client);
   }
 

--- a/tsoa/tfaws.w
+++ b/tsoa/tfaws.w
@@ -147,9 +147,9 @@ pub class Service_tfaws impl types.IService {
     this.url = deploy.invokeUrl;
   }
 
-  pub lift(id: str, client: std.Resource, ops: types.LiftOptions) {
+  pub lift(client: std.Resource, ops: types.LiftOptions) {
     client.onLift(this.func.fn, ops.allow);
-    this.clients.set(id, client);
+    this.clients.set(ops.id, client);
   }
 
   extern "./lib.js" static build(options: types.StartServiceOptions): str;

--- a/tsoa/types.w
+++ b/tsoa/types.w
@@ -44,6 +44,11 @@ pub struct ServiceProps {
  */
 pub struct LiftOptions {
   /**
+   * Id of the client
+   */
+  id: str;
+
+  /**
    * List of operations to allow for this client
    */
   allow: Array<str>;
@@ -53,5 +58,5 @@ pub struct LiftOptions {
  * Starts a new TSOA service.
  */
 pub interface IService {
-  lift(id: str, client: std.Resource, ops: LiftOptions): void;
+  lift(client: std.Resource, ops: LiftOptions): void;
 }

--- a/tsoa/types.w
+++ b/tsoa/types.w
@@ -40,8 +40,18 @@ pub struct ServiceProps {
 }
 
 /**
+ * Options for the lift method.
+ */
+pub struct LiftOptions {
+  /**
+   * List of operations to allow for this client
+   */
+  allow: Array<str>;
+}
+
+/**
  * Starts a new TSOA service.
  */
 pub interface IService {
-  liftClient(id: str, client: std.Resource, ops: Array<str>): void;
+  lift(id: str, client: std.Resource, ops: LiftOptions): void;
 }


### PR DESCRIPTION
- Changes API from (`liftClient`, `getClient`) to  (`lift`, `lifted`)
- Lift API is now `service.lift(resource, id: "name", allow: ["action"])`. didn't use `as` because it is highlighted as a special keyword in the IDE
- Uses [asynclocalstorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) instead of req for storing and passing lifted clients context
