### PR TITLE
docs(dynamodb): add docker prerequisite to DynamoDB README

### DIFF
--- a/dynamodb/README.md
+++ b/dynamodb/README.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 
 - [winglang](https://winglang.io).
+- [docker](https://www.docker.com/)
 
 ## Installation
 


### PR DESCRIPTION
# Description

* Add Docker as `prequisite` in README.md
As Docker is a requirement to run simulator locally, this PR adds it to the `prerequisite` list