### PR TITLE
fix(tsoa): does not compile with latest wing

### DIFF
--- a/tsoa/package.json
+++ b/tsoa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/tsoa",
   "description": "TSOA library for Wing",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": {
     "email": "eyalk@wing.cloud",
     "name": "Eyal Keren"

--- a/tsoa/tfaws.w
+++ b/tsoa/tfaws.w
@@ -11,7 +11,7 @@ struct BuildServiceResult {
   specFile: str;
 }
 
-class IFunction impl std.IInflightHost  {
+class Function impl std.IInflightHost {
   pub var _getCodeLines: (cloud.IFunctionHandler): Array<str>;
   pub var addEnvironment: (str, str): void;
 
@@ -21,9 +21,9 @@ class IFunction impl std.IInflightHost  {
   }
 }
 
-class TSOAFunction extends cloud.Function {
+class TSOAFunction {
   _env: MutMap<str>;
-  pub fn: IFunction;
+  pub fn: Function;
   requires: Map<str>;
 
   new(requires: Map<str>, handler: inflight (Json?, Json?, Map<std.Resource>?): Json?) {


### PR DESCRIPTION
There was an error saying that the class is missing a super() call. It looks like the implementation doesn't rely on extending cloud.Function, so I removed the `extends cloud.Function` code. I ran the unit test locally and on AWS and it passed on both.