### PR TITLE
feat(postgres): add preflight `db.connection`

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -27,6 +27,7 @@ let db = new postgres.Database(
 );
 
 let api = new cloud.Api();
+
 api.get("/users", inflight (req) => {
   let users = db.query("select * from users");
   return {
@@ -36,9 +37,35 @@ api.get("/users", inflight (req) => {
 });
 ```
 
+You can find connection information in `db.connection`:
+
+- `host` - the host to connect to
+- `port` - the external port to use (a token that will resolve at runtime)
+- `user` - user name
+- `password` - password
+- `database` - the database name
+- `ssl` - use SSL or not
+
 ## `sim`
 
 When executed in the Wing Simulator, postgres is run within a local Docker container.
+
+### Connecting to Postgres from `sim.Container`
+
+If you are connecting from a `sim.Container`, you should use `host.docker.internal` as the `host` in
+order to be able to access the host network:
+
+Example:
+
+```js
+new sim.Container(
+  // ...
+  env: {
+    DB_HOST: "host.docker.internal",
+    DB_PORT: db.connection.port
+  }
+)
+```
 
 ## `tf-aws`
 

--- a/postgres/lib.test.w
+++ b/postgres/lib.test.w
@@ -1,10 +1,19 @@
 bring expect;
 bring util;
 bring "./lib.w" as l;
+bring cloud;
+bring sim;
 
 let db = new l.Database(name: "test", pgVersion: 15);
+
+let myport = db.connection.port;
+assert(myport.contains("#attrs.port")); // <-- token
 
 test "run a simple query" {
   let result = db.query("SELECT 1 as one, 2 as two;");
   expect.equal(result[0], {one: 1, two: 2});
+}
+
+test "port is only resolved after the database is created" {
+  assert(num.fromStr(myport) > 10);
 }

--- a/postgres/lib.w
+++ b/postgres/lib.w
@@ -3,6 +3,7 @@ bring cloud;
 bring http;
 bring util;
 bring sim;
+bring ui;
 bring "constructs" as constructs;
 bring "cdktf" as cdktf;
 bring "@rybickic/cdktf-provider-neon" as rawNeon;
@@ -10,7 +11,7 @@ bring "@cdktf/provider-aws" as tfaws;
 
 pub struct ConnectionOptions {
   host: str;
-  port: num?; // default: 5432
+  port: str;
   user: str;
   password: str;
   database: str;
@@ -35,14 +36,18 @@ pub interface IDatabase {
 }
 
 pub class Database {
-
+  pub connection: ConnectionOptions;
   inner: IDatabase;
   new(props: DatabaseProps) {
     let target = util.env("WING_TARGET");
     if target == "sim" {
-      this.inner = new DatabaseSim(props);
+      let sim = new DatabaseSim(props);
+      this.connection = sim.connection;
+      this.inner = sim;
     } elif target == "tf-aws" {
-      this.inner = new DatabaseNeon(props);
+      let neon = new DatabaseNeon(props);
+      this.connection = neon.connection;
+      this.inner = neon;
     } else {
       throw "Unsupported target: " + target;
     }
@@ -58,6 +63,9 @@ pub class Database {
 
 class DatabaseSim impl IDatabase {
   port: str;
+
+  pub connection: ConnectionOptions;
+
   new(props: DatabaseProps) {
     let image = "postgres:{props.pgVersion ?? 15}";
     let container = new sim.Container(
@@ -70,21 +78,39 @@ class DatabaseSim impl IDatabase {
       volumes: ["/var/lib/postgresql/data"],
       // TODO: implement readiness check?
     );
-    this.port = container.hostPort!;
-  }
-  pub inflight connectionOptions(): ConnectionOptions  {
-    return {
+
+    let state = new sim.State();
+    this.port = state.token("port");
+
+    new cloud.Service(inflight () => {
+      log("Waiting for Postgres to listen on {container.hostPort!}...");
+
+      util.waitUntil(() => {
+        return PgUtil.isPortOpen(container.hostPort!);
+      });
+
+      log("Postgres is ready on port {container.hostPort!}");
+      state.set("port", container.hostPort!);
+    });
+
+    this.connection = {
       host: "localhost",
       password: "password",
       database: "postgres",
       user: "postgres",
-      port: num.fromStr(this.port),
+      port: this.port,
       ssl: false,
     };
+
+    new ui.ValueField("Postgres Port", this.port);
+  }
+
+  pub inflight connectionOptions(): ConnectionOptions {
+    return this.connection;
   }
 
   pub inflight query(query: str): Array<Map<Json>> {
-    return PgUtil._query(query, this.connectionOptions());
+    return PgUtil._query(query, this.connection);
   }
 }
 
@@ -96,7 +122,7 @@ struct DbCredentials {
 }
 
 class DatabaseNeon impl IDatabase {
-  creds: cloud.Secret;
+  pub connection: ConnectionOptions;
 
   new(props: DatabaseProps) {
     this.neonProvider();
@@ -113,23 +139,16 @@ class DatabaseNeon impl IDatabase {
       branchId: project.defaultBranchId,
       ownerName: project.databaseUser,
       name: props.name,
-
     );
 
-    this.creds = new cloud.Secret() as "NeonCredentials";
-
-
-    // TODO: avoid hard-coding for AWS
-    let secretsManagerSecret: tfaws.secretsmanagerSecret.SecretsmanagerSecret = unsafeCast(this.creds.node.findChild("Default"));
-    let secretVersion = new tfaws.secretsmanagerSecretVersion.SecretsmanagerSecretVersion(
-      secretId: secretsManagerSecret.id,
-      secretString: cdktf.Fn.jsonencode({
-        host: project.databaseHost,
-        user: project.databaseUser,
-        password: project.databasePassword,
-        database: project.databaseName,
-      })
-    ) as "NeonCredentialsVersion";
+    this.connection = {
+      database: project.databaseName,
+      host: project.databaseHost,
+      password: project.databasePassword,
+      port: "5432",
+      ssl: true,
+      user: project.databaseUser,
+    };
   }
 
   neonProvider(): cdktf.TerraformProvider {
@@ -142,15 +161,9 @@ class DatabaseNeon impl IDatabase {
 
     return new rawNeon.provider.NeonProvider() as singletonKey in stack;
   }
+
   pub inflight connectionOptions(): ConnectionOptions {
-    let creds = DbCredentials.fromJson(this.creds.valueJson());
-    return {
-        host: creds.host,
-        user: creds.user,
-        password: creds.password,
-        database: creds.database,
-        ssl: true,
-    };
+    return this.connection;
   }
 
   pub inflight query(query: str): Array<Map<Json>> {
@@ -160,4 +173,5 @@ class DatabaseNeon impl IDatabase {
 
 class PgUtil {
   pub extern "./pg.js" static inflight _query(query: str, creds: ConnectionOptions): Array<Map<Json>>;
+  pub extern "./util.ts" static inflight isPortOpen(port: str): bool;
 }

--- a/postgres/pg.extern.d.ts
+++ b/postgres/pg.extern.d.ts
@@ -5,7 +5,7 @@ export interface ConnectionOptions {
   readonly database: string;
   readonly host: string;
   readonly password: string;
-  readonly port?: (number) | undefined;
+  readonly port: string;
   readonly ssl: boolean;
   readonly user: string;
 }

--- a/postgres/util.extern.d.ts
+++ b/postgres/util.extern.d.ts
@@ -1,0 +1,3 @@
+export default interface extern {
+  isPortOpen: (port: string) => Promise<boolean>,
+}

--- a/postgres/util.ts
+++ b/postgres/util.ts
@@ -1,0 +1,19 @@
+import { Socket } from "net";
+import type extern from "./util.extern";
+
+export const isPortOpen: extern["isPortOpen"] = async (port) => {
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+
+    client.connect(port);
+
+    client.once("error", (err) => {
+      resolve(false);
+    });
+
+    client.once("connect", () => {
+      client.end();
+      resolve(true);
+    });
+  });
+};


### PR DESCRIPTION
Add `db.connection` as a preflight object so things like `db.connection.host`, `db.connection.port`, etc can be used as environment variables preflight.

In `sim`, wait for the database to listen before resolving the `port`. This means dependencies w ill only get initialized when the database is up.