### PR TITLE
chore: improve tests-all.sh

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
+
+WING=${WING:-wing}
 
 for i in $(ls -F); do
   if [ -f "$i/package.json" ]; then
@@ -9,7 +11,11 @@ for i in $(ls -F); do
     (
       cd $i
       npm i
-      wing test
+      if [ -x test.sh ]; then
+        ./test.sh
+      else
+        $WING test
+      fi
     )
   fi
 done


### PR DESCRIPTION
* Can specify specific wing binary to use for tests
* Explicitly use `bash` so `pipefail` will work
* Use custom `test.sh` when avaialble (for cdk8s)