### PR TITLE
feat(dynamodb): adding update call to dynamodb library

### DIFF
--- a/dynamodb/dynamodb-client.w
+++ b/dynamodb/dynamodb-client.w
@@ -61,6 +61,12 @@ pub inflight class Client impl dynamodb_types.IClient {
     return unsafeCast(this.client.put(input));
   }
 
+  pub inflight update(options: dynamodb_types.UpdateOptions):  dynamodb_types.UpdateOutput {
+    let input: MutJson = options;
+    input.set("TableName", this.tableName);
+    return unsafeCast(this.client.update(input)); 
+  }
+
   pub inflight transactWrite(options: dynamodb_types.TransactWriteOptions): dynamodb_types.TransactWriteOutput {
     let transactItems = MutArray<Json> [];
     for item in options.TransactItems {

--- a/dynamodb/dynamodb-types.w
+++ b/dynamodb/dynamodb-types.w
@@ -46,9 +46,20 @@ pub struct PutOptions {
   ReturnValues: str?;
 }
 
+pub struct UpdateOptions {
+  Key: Json;
+  ReturnValues: str?;
+  ReturnConsumedCapacity: str?;
+  UpdateExpression: str;
+  ConditionExpression: str?;
+  ExpressionAttributeNames: Map<str>?;
+  ExpressionAttributeValues: Map<Json>?;
+}
+
 pub struct PutOutput {
   Attributes: Json?;
 }
+pub struct UpdateOutput extends PutOptions {}
 
 pub struct QueryOptions {
   ConsistentRead: bool?;
@@ -201,6 +212,7 @@ pub inflight interface IClient {
   inflight delete(options: DeleteOptions): DeleteOutput;
   inflight get(options: GetOptions): GetOutput;
   inflight put(options: PutOptions): PutOutput;
+  inflight update(options: UpdateOptions): UpdateOutput;
   inflight query(options: QueryOptions): QueryOutput;
   inflight scan(options: ScanOptions?): ScanOutput;
   inflight transactWrite(options: TransactWriteOptions): TransactWriteOutput;

--- a/dynamodb/dynamodb.sim.w
+++ b/dynamodb/dynamodb.sim.w
@@ -275,6 +275,10 @@ pub class Table_sim impl dynamodb_types.ITable {
     return this.client.put(options);
   }
 
+  pub inflight update(options: dynamodb_types.UpdateOptions): dynamodb_types.UpdateOutput {
+    return this.client.update(options);
+  }
+
   pub inflight transactWrite(options: dynamodb_types.TransactWriteOptions): dynamodb_types.TransactWriteOutput {
     return this.client.transactWrite(options);
   }

--- a/dynamodb/dynamodb.tf-aws.w
+++ b/dynamodb/dynamodb.tf-aws.w
@@ -184,6 +184,10 @@ pub class Table_tfaws impl dynamodb_types.ITable {
     return this.client.put(options);
   }
 
+  pub inflight update(options: dynamodb_types.UpdateOptions): dynamodb_types.UpdateOutput {
+    return this.client.update(options);
+  }
+
   pub inflight transactWrite(options: dynamodb_types.TransactWriteOptions): dynamodb_types.TransactWriteOutput {
     return this.client.transactWrite(options);
   }

--- a/dynamodb/dynamodb.w
+++ b/dynamodb/dynamodb.w
@@ -61,6 +61,10 @@ pub class Table impl dynamodb_types.ITable {
     return this.implementation.put(options);
   }
 
+  pub inflight update(options: dynamodb_types.UpdateOptions): dynamodb_types.UpdateOutput {
+    return this.implementation.update(options);
+  }
+
   pub inflight transactWrite(options: dynamodb_types.TransactWriteOptions): dynamodb_types.TransactWriteOutput {
     return this.implementation.transactWrite(options);
   }

--- a/dynamodb/tests/update.test.w
+++ b/dynamodb/tests/update.test.w
@@ -1,0 +1,42 @@
+bring cloud;
+bring "../dynamodb.w" as dynamodb;
+
+let table = new dynamodb.Table(
+  attributes: [
+    {
+      name: "id",
+      type: "S",
+    },
+  ],
+  hashKey: "id",
+) as "table1";
+
+test "update" {
+  table.put(
+    Item: {
+      id: "1",
+      val1: "anything",
+      val2: "something"
+    },
+  );
+
+  let var response = table.query(
+    KeyConditionExpression: "id = :id",
+    ExpressionAttributeValues: {":id": "1"},
+  );
+  assert(response.Items[0]["val1"].asStr() == "anything");
+  assert(response.Items[0]["val2"].asStr() == "something");
+
+  table.update(
+    Key: { id: "1" },
+    UpdateExpression: "SET val2 = :v",
+    ExpressionAttributeValues: {":v": "everything"}
+  );
+
+  response = table.query(
+    KeyConditionExpression: "id = :id",
+    ExpressionAttributeValues: {":id": "1"},
+  );
+  assert(response.Items[0]["val1"].asStr() == "anything");
+  assert(response.Items[0]["val2"].asStr() == "everything");
+}


### PR DESCRIPTION
It was not possible to partially update an item with the current methods (it might be possible with `transactWrite`, but it seemed counterintuitive to me). I added the `update` method to allow this.