### PR TITLE
fix(dynamodb): adding global index to tf-aws target

### DIFF
--- a/dynamodb/dynamodb.tf-aws.w
+++ b/dynamodb/dynamodb.tf-aws.w
@@ -62,6 +62,7 @@ pub class Table_tfaws impl dynamodb_types.ITable {
       pointInTimeRecovery: {
         enabled: props.pointInTimeRecovery,
       },
+      globalSecondaryIndex: props.globalSecondaryIndex,
     });
 
     this.tableName = this.table.name;
@@ -158,6 +159,7 @@ pub class Table_tfaws impl dynamodb_types.ITable {
           effect: aws.Effect.ALLOW,
           resources: [
             this.table.arn,
+            "{this.table.arn}/index/*",
           ],
         });
       }

--- a/dynamodb/package-lock.json
+++ b/dynamodb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/dynamodb",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/dynamodb",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-dynamodb": "^3.461.0",

--- a/dynamodb/package-lock.json
+++ b/dynamodb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/dynamodb",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/dynamodb",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-dynamodb": "^3.461.0",

--- a/dynamodb/package.json
+++ b/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/dynamodb",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "DynamoDB library for Wing",
   "author": {
     "name": "Cristian Pallarés",


### PR DESCRIPTION
The `compatibility.gsi.test.w` test was not working on AWS, so I added the configuration during table creation and the permission to access the global index.