### PR TITLE
fix(momento): adding momento api key to terraform provider 

### DIFF
--- a/momento/cache.w
+++ b/momento/cache.w
@@ -43,7 +43,7 @@ pub class Cache {
     let defaultTtl = props.defaultTtl ?? 60s;
     if target.startsWith("tf") {
       this.inner = new Cache_tf({ token, name, defaultTtl });
-    } if target == "sim" {
+    } elif target == "sim" {
       this.inner = new Cache_sim({ token, name, defaultTtl });
     } else {
       throw "unsupported target: " + target;
@@ -155,6 +155,9 @@ class MomentoProvider {
       name: "momento",
       source: "momentohq/momento",
       version: "0.1.0",
+      attributes: {
+        api_key: util.env("MOMENTO_API_KEY"),
+      }
     ) as singletonKey in root;
   }
 }

--- a/momento/package.json
+++ b/momento/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/momento",
   "description": "momento library for Wing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",


### PR DESCRIPTION
I added the momento api key to the Terraform provider, making it mandatory for the MOMENTO_API_KEY environment variable to be configured, and fixed a bug that caused an exception when compiling for the tf-aws target.