### PR TITLE
fix(bedrock)!: hide internal APIs

### DIFF
--- a/bedrock/api.w
+++ b/bedrock/api.w
@@ -1,4 +1,3 @@
-
-pub interface IModel {
+internal interface IModel {
   inflight invoke(body: Json): Json;  
 }

--- a/bedrock/bedrock.sim.w
+++ b/bedrock/bedrock.sim.w
@@ -1,6 +1,6 @@
 bring "./api.w" as b;
 
-pub class Model_sim impl b.IModel {
+internal class Model_sim impl b.IModel {
   modelId: str;
   var mockResponse: inflight (Json): Json;
 

--- a/bedrock/bedrock.tfaws.w
+++ b/bedrock/bedrock.tfaws.w
@@ -1,7 +1,7 @@
 bring "./api.w" as b;
 bring aws;
 
-pub class Model_tfaws impl b.IModel {
+internal class Model_tfaws impl b.IModel {
   pub modelId: str;
 
   new(modelId: str) {

--- a/bedrock/package-lock.json
+++ b/bedrock/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/bedrock",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/bedrock",
-      "version": "0.0.10",
+      "version": "0.1.0",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.484.0"

--- a/bedrock/package-lock.json
+++ b/bedrock/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/bedrock",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/bedrock",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.484.0"

--- a/bedrock/package.json
+++ b/bedrock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/bedrock",
   "description": "A Wing library for Amazon Bedrock",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": {
     "name": "Eyal Keren",
     "email": "eyalk@wing.cloud"

--- a/bedrock/package.json
+++ b/bedrock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/bedrock",
   "description": "A Wing library for Amazon Bedrock",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "author": {
     "name": "Eyal Keren",
     "email": "eyalk@wing.cloud"


### PR DESCRIPTION
Update the library using the features from https://github.com/winglang/wing/pull/6980 so that APIs intended to be private are now marked as `internal`.

Marked as a breaking change since it was possible for consumers to have used these internal APIs in the past (even if it was unintended).