### PR TITLE
fix(winglib): set default value for dynamodb winglib starting positio…

### DIFF
--- a/dynamodb/dynamodb.tf-aws.w
+++ b/dynamodb/dynamodb.tf-aws.w
@@ -76,6 +76,9 @@ pub class Table_tfaws impl dynamodb_types.ITable {
   }
 
   pub setStreamConsumer(handler: inflight (dynamodb_types.StreamRecord): void, options: dynamodb_types.StreamConsumerOptions?) {
+
+    let startingPosition = options?.startingPosition ?? "LATEST";
+
     let consumer = new cloud.Function(inflight (eventStr) => {
       let event: DynamoDBStreamEvent = unsafeCast(eventStr);
       for record in event.Records {
@@ -120,7 +123,7 @@ pub class Table_tfaws impl dynamodb_types.ITable {
           eventSourceArn: this.table.streamArn,
           functionName: lambda.functionName,
           batchSize: options?.batchSize,
-          startingPosition: options?.startingPosition,
+          startingPosition,
           // filterCriteria: unsafeCast(options?.filterCriteria),
         },
       );


### PR DESCRIPTION
Fix for https://github.com/winglang/wing/issues/7178

Sets a default value for DynamoDB streams to the starting position to be `LATEST`