### PR TITLE
chore: bump all winglibs versions

### DIFF
--- a/bedrock/package-lock.json
+++ b/bedrock/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/bedrock",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/bedrock",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.484.0"

--- a/bedrock/package.json
+++ b/bedrock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/bedrock",
   "description": "A Wing library for Amazon Bedrock",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Eyal Keren",
     "email": "eyalk@wing.cloud"

--- a/budget/package-lock.json
+++ b/budget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/budget",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/budget",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "peerDependencies": {
         "@cdktf/provider-aws": "^19.12.0",

--- a/budget/package.json
+++ b/budget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/budget",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "AWS Budget",
   "keywords": [
     "AWS",

--- a/checks/package-lock.json
+++ b/checks/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/checks",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/checks",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT"
     }
   }

--- a/checks/package.json
+++ b/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/checks",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Cloud checks",
   "publishConfig": {
     "access": "public",

--- a/cloudv2/package-lock.json
+++ b/cloudv2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/cloudv2",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/cloudv2",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-dynamodb": "^3.621.0",

--- a/cloudv2/package.json
+++ b/cloudv2/package.json
@@ -5,7 +5,7 @@
     "email": "chrisr@wing.cloud",
     "name": "Chris Rybicki"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/cognito/package-lock.json
+++ b/cognito/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/cognito",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/cognito",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-cognito-identity": "^3.564.0",

--- a/cognito/package.json
+++ b/cognito/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/cognito",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "A wing library to work with AWS Cognito",
   "author": {
     "name": "Elad Cohen",

--- a/containers/package-lock.json
+++ b/containers/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/containers",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/containers",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "peerDependencies": {
         "@cdktf/provider-aws": "^19.12.0",

--- a/containers/package.json
+++ b/containers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/containers",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Container support for Wing",
   "repository": {
     "type": "git",

--- a/dynamodb/package-lock.json
+++ b/dynamodb/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/dynamodb",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/dynamodb",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-dynamodb": "^3.461.0",

--- a/dynamodb/package.json
+++ b/dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/dynamodb",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "DynamoDB library for Wing",
   "author": {
     "name": "Cristian Pallarés",

--- a/email/package-lock.json
+++ b/email/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/email",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/email",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-sesv2": "^3.651.1",

--- a/email/package.json
+++ b/email/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/email",
   "description": "An email library for Wing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": {
     "name": "Chris Rybicki",
     "email": "chrisr@wing.cloud"

--- a/eventbridge/package-lock.json
+++ b/eventbridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/eventbridge",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/eventbridge",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-eventbridge": "^3.525.0",

--- a/eventbridge/package.json
+++ b/eventbridge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/eventbridge",
   "description": "Amazon EventBridge library for Wing",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/fifoqueue/package-lock.json
+++ b/fifoqueue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/fifoqueue",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/fifoqueue",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-sqs": "^3.460.0",

--- a/fifoqueue/package.json
+++ b/fifoqueue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/fifoqueue",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A wing library to work with FIFO (first-in first-out) Queues",
   "author": {
     "name": "Elad Cohen",

--- a/github/package-lock.json
+++ b/github/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/github",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/github",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "license": "MIT",
       "peerDependencies": {
         "@probot/adapter-aws-lambda-serverless": "^3.0.4",

--- a/github/package.json
+++ b/github/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/github",
   "description": "A Wing library for GitHub Probot",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "author": {
     "name": "Elad Cohen",
     "email": "eladc@wing.cloud"

--- a/jwt/package-lock.json
+++ b/jwt/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/jwt",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/jwt",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "peerDependencies": {
         "jsonwebtoken": "^9.0.2",

--- a/jwt/package.json
+++ b/jwt/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/jwt",
   "description": "Wing library for JWT authentication",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/k8s/package-lock.json
+++ b/k8s/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/k8s",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/k8s",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "devDependencies": {
         "cdk8s-plus-27": "^2.9.0"

--- a/k8s/package.json
+++ b/k8s/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/k8s",
   "description": "Wing for Kubernetes",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": {
     "name": "Elad Ben-Israel",
     "email": "eladb@wing.cloud"

--- a/lock/package-lock.json
+++ b/lock/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/lock",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/lock",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT"
     }
   }

--- a/lock/package.json
+++ b/lock/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/lock",
   "description": "A Wing library for cloud Lock",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": {
     "name": "Eyal Keren",
     "email": "eyalk@wing.cloud"

--- a/messagefanout/package-lock.json
+++ b/messagefanout/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/messagefanout",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/messagefanout",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-sns": "^3.511.0",

--- a/messagefanout/package.json
+++ b/messagefanout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/messagefanout",
   "description": "Message fanout library for Wing",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/momento/package-lock.json
+++ b/momento/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/momento",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/momento",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "peerDependencies": {
         "@gomomento/sdk": "^1.93.0",

--- a/momento/package.json
+++ b/momento/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/momento",
   "description": "momento library for Wing",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/ngrok/package-lock.json
+++ b/ngrok/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/ngrok",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/ngrok",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "MIT",
       "peerDependencies": {
         "@ngrok/ngrok": "^0.9.1"

--- a/ngrok/package.json
+++ b/ngrok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/ngrok",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "ngrok library for Wing",
   "author": {
     "name": "Elad Ben-Israel",

--- a/openai/package-lock.json
+++ b/openai/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/openai",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/openai",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "peerDependencies": {
         "openai": "^4.28.4"

--- a/openai/package.json
+++ b/openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/openai",
   "description": "OpenAI library for Wing",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/postgres/package-lock.json
+++ b/postgres/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/postgres",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/postgres",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "peerDependencies": {
         "@cdktf/provider-aws": "^19.12.0",

--- a/postgres/package.json
+++ b/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/postgres",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Postgres support for Wing",
   "repository": {
     "type": "git",

--- a/python/package-lock.json
+++ b/python/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/python",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/python",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-lambda": "^3.549.0",

--- a/python/package.json
+++ b/python/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/python",
   "description": "python library for Wing",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/react",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/react",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "peerDependencies": {
         "finalhandler": "^1.2.0",

--- a/react/package.json
+++ b/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/react",
   "description": "React library for Wing",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": {
     "name": "Meir Elbaz",
     "email": "maornet@gmail.com"

--- a/react/test/react-project/package-lock.json
+++ b/react/test/react-project/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reactapp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reactapp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",

--- a/react/test/react-project/package.json
+++ b/react/test/react-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactapp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/redis/package-lock.json
+++ b/redis/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/redis",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/redis",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MIT",
       "peerDependencies": {
         "@winglibs/containers": "^0.1.2",

--- a/redis/package.json
+++ b/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/redis",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Redis resource for Wing",
   "repository": {
     "type": "git",

--- a/sagemaker/package-lock.json
+++ b/sagemaker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/sagemaker",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/sagemaker",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-sagemaker-runtime": "^3.507.0"

--- a/sagemaker/package.json
+++ b/sagemaker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/sagemaker",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "The library enables owners of a trained sagemaker model, to access its Endpoints from a winglang inflight code.",
   "repository": {
     "type": "git",

--- a/ses/package-lock.json
+++ b/ses/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/ses",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/ses",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-ses": "^3.572.0",

--- a/ses/package.json
+++ b/ses/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/ses",
   "description": "Wing library for interacting with AWS SES",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/simtools/package-lock.json
+++ b/simtools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/simtools",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/simtools",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT"
     }
   }

--- a/simtools/package.json
+++ b/simtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/simtools",
   "description": "Wing simulator utility library",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/slack/package-lock.json
+++ b/slack/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/slack",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/slack",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "peerDependencies": {
         "cdktf": "0.20.7"

--- a/slack/package.json
+++ b/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/slack",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Slack library for Wing",
   "repository": {
     "type": "git",

--- a/sns/package-lock.json
+++ b/sns/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/sns",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/sns",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "peerDependencies": {
         "@aws-sdk/client-sns": "^3.577.0"

--- a/sns/package.json
+++ b/sns/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/sns",
   "description": "Wing library for interacting with Amazon SNS",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/tf/package-lock.json
+++ b/tf/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/tf",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/tf",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "peerDependencies": {
         "cdktf": "*"

--- a/tf/package.json
+++ b/tf/package.json
@@ -5,7 +5,7 @@
     "email": "eladb@wing.cloud",
     "name": "Elad Ben-Israel"
   },
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",

--- a/tsoa/package-lock.json
+++ b/tsoa/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/tsoa",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/tsoa",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "peerDependencies": {
         "@cdktf/provider-aws": "^19.13.0",

--- a/tsoa/package.json
+++ b/tsoa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/tsoa",
   "description": "TSOA library for Wing",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "author": {
     "email": "eyalk@wing.cloud",
     "name": "Eyal Keren"

--- a/vite/package-lock.json
+++ b/vite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/vite",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/vite",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "peerDependencies": {
         "@cdktf/provider-aws": "^19.12.0",

--- a/vite/package.json
+++ b/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@winglibs/vite",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Wing resource that allows deploying a Vite application to the cloud",
   "repository": {
     "type": "git",

--- a/websockets/package-lock.json
+++ b/websockets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@winglibs/websockets",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@winglibs/websockets",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "license": "MIT",
       "devDependencies": {
         "@types/ws": "^8.5.10"

--- a/websockets/package.json
+++ b/websockets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@winglibs/websockets",
   "description": "WebSocket library for Wing",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/winglang/winglibs.git",


### PR DESCRIPTION
At some point, the npm token used for publishing expired and many packages may have unpublished changes.